### PR TITLE
retire core<site>_production puppet env naming convention

### DIFF
--- a/hieradata/site/cp/role/foreman.yaml
+++ b/hieradata/site/cp/role/foreman.yaml
@@ -210,8 +210,7 @@ puppet::server::puppetdb::server: "puppetdb.cp.lsst.org"
 r10k::sources:
   control:
     ignore_branch_prefixes: &ignore_branch
-      - "coredev_production"
-      - "corels_production"
+      - "core"
       - "dev"
       - "ls"
       - "tu"

--- a/hieradata/site/dev/role/foreman.yaml
+++ b/hieradata/site/dev/role/foreman.yaml
@@ -19,8 +19,7 @@ puppet::server::puppetdb::server: "puppetdb.dev.lsst.org"
 r10k::sources:
   control:
     ignore_branch_prefixes: &ignore_branch
-      - "corels_production"
-      - "corecp_production"
+      - "core"
       - "cp"
       - "ls"
       - "tu"

--- a/hieradata/site/ls/role/foreman.yaml
+++ b/hieradata/site/ls/role/foreman.yaml
@@ -87,8 +87,7 @@ puppet::server::puppetdb::server: "puppetdb.ls.lsst.org"
 r10k::sources:
   control:
     ignore_branch_prefixes: &ignore_branch
-      - "corecp_production"
-      - "coredev_production"
+      - "core"
       - "cp"
       - "dev"
       - "tu"

--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -77,9 +77,7 @@ puppet::server::puppetdb::server: "puppetdb.tu.lsst.org"
 r10k::sources:
   control:
     ignore_branch_prefixes: &ignore_branch
-      - "corecp_production"
-      - "coredev_production"
-      - "corels_production"
+      - "core"
       - "cp"
       - "dev"
       - "ls"


### PR DESCRIPTION
Replaced with <site>_production.