### PR TITLE
(role/foreman) retire {dev,tu,ls}_production env name

### DIFF
--- a/hieradata/site/dev/role/foreman.yaml
+++ b/hieradata/site/dev/role/foreman.yaml
@@ -25,6 +25,7 @@ r10k::sources:
     ignore_branch_prefixes: &ignore_branch
       - "core"
       - "cp"
+      - "dev"
       - "ls"
       - "tu"
   lsst_hiera_private:

--- a/hieradata/site/ls/role/foreman.yaml
+++ b/hieradata/site/ls/role/foreman.yaml
@@ -187,6 +187,7 @@ r10k::sources:
       - "core"
       - "cp"
       - "dev"
+      - "ls"
       - "tu"
   lsst_hiera_private:
     ignore_branch_prefixes: *ignore_branch

--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -111,5 +111,6 @@ r10k::sources:
       - "cp"
       - "dev"
       - "ls"
+      - "tu"
   lsst_hiera_private:
     ignore_branch_prefixes: *ignore_branch

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -37,6 +37,7 @@ describe "#{role} role" do
             disable
             core
             cp
+            dev
             ls
             tu
           ]
@@ -75,6 +76,7 @@ describe "#{role} role" do
             cp
             dev
             ls
+            tu
           ]
         end
 
@@ -204,6 +206,7 @@ describe "#{role} role" do
             core
             cp
             dev
+            ls
             tu
           ]
         end


### PR DESCRIPTION
The `{dev,tu,ls}_production` envs are to be replaced with `production`.
The `cp_production` env is still retained for use at the summit.

Based on #753 