### PR TITLE
(dimm.cp) add network config and tests

### DIFF
--- a/hieradata/node/dimm.cp.lsst.org.yaml
+++ b/hieradata/node/dimm.cp.lsst.org.yaml
@@ -1,0 +1,33 @@
+profile::nm::connections:
+  eno1:
+    content: |
+      [connection]
+      id=eno1
+      uuid=250c1a0b-95c3-4798-a4df-d864e60d3b63
+      type=ethernet
+      autoconnect=true
+      interface-name=eno1
+
+      [ethernet]
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      method=disabled
+  enp2s0:
+    content: |
+      [connection]
+      id=enp2s0
+      uuid=de9904c8-9577-1a17-36b1-34b94132f06a
+      type=ethernet
+      autoconnect=false
+      interface-name=enp2s0
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled

--- a/spec/hosts/nodes/dimm.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/dimm.cp.lsst.org_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'dimm.cp.lsst.org', :site do
+  alma8 = FacterDB.get_facts({ operatingsystem: 'AlmaLinux', operatingsystemmajrelease: '8' }).first
+  # rubocop:disable Naming/VariableNumber
+  { 'almalinux-8-x86_64': alma8 }.each do |os, facts|
+    # rubocop:enable Naming/VariableNumber
+    context "on #{os}" do
+      let(:facts) { override_facts(facts, fqdn: 'dimm.cp.lsst.org') }
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'cp',
+        }
+      end
+
+      include_context 'with nm interface'
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to have_network__interface_resource_count(0) }
+      it { is_expected.to have_profile__nm__connection_resource_count(2) }
+
+      context 'with eno1' do
+        let(:interface) { 'eno1' }
+
+        it_behaves_like 'nm named interface'
+        it_behaves_like 'nm dhcp interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('ethernet') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be(true) }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('auto') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+      end
+
+      context 'with enp2s0' do
+        let(:interface) { 'enp2s0' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('ethernet') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be(false) }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('disabled') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
the Dimm was migrated from a VM to a Bare Metal fanless server and installed with Alma 8, there was no networking config and puppet was deleting the interfaces on each run, so we created the network configuration for it.