### PR TITLE
(ccs) add hiera settings for BTS

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -86,26 +86,6 @@ accounts::user_list:
 ccs_software::desktop: true
 ccs_software::env: "AuxTel"
 ccs_software::installations:
-  ats-software-2.0.0:
-    aliases:
-      - "puppet-2.0.0"
-
-  ats-software-2.1.0:
-    aliases:
-      - "puppet-2.1.0"
-
-  ats-software-2.1.1:
-    aliases:
-      - "puppet-2.1.1"
-
-  ats-software-2.2.0:
-    aliases:
-      - "puppet-2.2.0"
-
-  ats-software-2.2.1:
-    aliases:
-      - "puppet-2.2.1"
-
   ats-software-2.2.3:
     aliases:
       - "puppet-2.2.3"

--- a/hieradata/site/ls/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/ls/cluster/auxtel-ccs.yaml
@@ -1,0 +1,15 @@
+---
+ccs_site: "base"
+ccs_sal::dds_interface: "auxtel-mcm-dds.ls.lsst.org"
+
+## base-teststand-alerts
+ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
+
+ccs_monit::alert:
+  - "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
+
+clustershell::groupmembers:
+  misc: {group: "misc", member: "auxtel-mcm,auxtel-dc01,auxtel-fp01"}
+  #hcu: {group: "hcu", member: "auxtel-hcu01"}
+  #all: {group: "all", member: "@misc,@hcu"}
+  all: {group: "all", member: "@misc"}

--- a/hieradata/site/ls/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/ls/cluster/lsstcam-ccs.yaml
@@ -1,4 +1,13 @@
 ---
+ccs_site: "base"
+ccs_sal::dds_interface: "lsstcam-mcm-dds.ls.lsst.org"
+
+## base-teststand-alerts
+ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
+
+ccs_monit::alert:
+  - "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
+
 profile::nm::connections:
   eno1np0:
     content: |

--- a/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
@@ -85,6 +85,21 @@ describe 'auxtel-mcm.ls.lsst.org', :site do
       it { is_expected.to contain_service('localdb') }
       it { is_expected.to contain_service('rest-server') }
 
+      it do
+        is_expected.to contain_class('clustershell').with(
+          groupmembers: {
+            'misc' => {
+              'group' => 'misc',
+              'member' => 'auxtel-mcm,auxtel-dc01,auxtel-fp01',
+            },
+            'all' => {
+              'group' => 'all',
+              'member' => '@misc',
+            },
+          },
+        )
+      end
+
       it { is_expected.to compile.with_all_deps }
 
       it do

--- a/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
@@ -73,6 +73,12 @@ describe 'auxtel-mcm.ls.lsst.org', :site do
       it { is_expected.to contain_file('/etc/ccs/ccsGlobal.properties').with_content(%r{^org.hibernate.engine.internal.level=WARNING}) }
       it { is_expected.to contain_file('/etc/ccs/ccsGlobal.properties').with_content(%r{^.level=WARNING}) }
 
+      it { is_expected.to contain_file('/etc/ccs/systemd-email').with_content(%r{^EMAIL=base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com}) }
+
+      it { is_expected.to contain_file('/etc/monit.d/alert').with_content(%r{^set alert base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com}) }
+
+      it { is_expected.to contain_file('/etc/ccs/setup-sal5').with_content(%r{^export LSST_DDS_INTERFACE=auxtel-mcm-dds.ls.lsst.org}) }
+
       it { is_expected.to contain_class('Ccs_software::Service') }
       it { is_expected.to contain_service('mmm') }
       it { is_expected.to contain_service('cluster-monitor') }

--- a/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-mcm.ls.lsst.org_spec.rb
@@ -79,6 +79,8 @@ describe 'auxtel-mcm.ls.lsst.org', :site do
 
       it { is_expected.to contain_file('/etc/ccs/setup-sal5').with_content(%r{^export LSST_DDS_INTERFACE=auxtel-mcm-dds.ls.lsst.org}) }
 
+      it { is_expected.to contain_file('/etc/ccs/setup-sal5').with_content(%r{^export LSST_DDS_PARTITION_PREFIX=base}) }
+
       it { is_expected.to contain_class('Ccs_software::Service') }
       it { is_expected.to contain_service('mmm') }
       it { is_expected.to contain_service('cluster-monitor') }

--- a/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
@@ -21,6 +21,7 @@ describe 'lsstcam-db01.ls.lsst.org', :site do
         {
           role: 'ccs-database',
           site: 'ls',
+          cluster: 'lsstcam-ccs',
         }
       end
 

--- a/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
@@ -24,6 +24,10 @@ describe 'lsstcam-db01.ls.lsst.org', :site do
         }
       end
 
+      it { is_expected.to contain_file('/etc/ccs/systemd-email').with_content(%r{^EMAIL=base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com}) }
+
+      it { is_expected.to contain_file('/etc/monit.d/alert').with_content(%r{^set alert base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com}) }
+
       it { is_expected.to compile.with_all_deps }
 
       include_context 'with nm interface'

--- a/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-db01.ls.lsst.org_spec.rb
@@ -34,7 +34,7 @@ describe 'lsstcam-db01.ls.lsst.org', :site do
       include_context 'with nm interface'
 
       it { is_expected.to have_network__interface_resource_count(0) }
-      it { is_expected.to have_profile__nm__connection_resource_count(5) }
+      it { is_expected.to have_profile__nm__connection_resource_count(7) }
 
       %w[
         eno1np0
@@ -56,6 +56,32 @@ describe 'lsstcam-db01.ls.lsst.org', :site do
         it_behaves_like 'nm dhcp interface'
         it { expect(nm_keyfile['connection']['type']).to eq('ethernet') }
         it { expect(nm_keyfile['connection']['autoconnect']).to be_nil }
+      end
+
+      context 'with enp129s0f1.2505' do
+        let(:interface) { 'enp129s0f1.2505' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('vlan') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be_nil }
+        it { expect(nm_keyfile['connection']['master']).to eq('br2505') }
+        it { expect(nm_keyfile['connection']['slave-type']).to eq('bridge') }
+      end
+
+      context 'with br2505' do
+        let(:interface) { 'br2505' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('bridge') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be_nil }
+        it { expect(nm_keyfile['bridge']['stp']).to be false }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('disabled') }
+        it { expect(nm_keyfile['ipv4']['route1']).to eq('139.229.153.0/24') }
+        it { expect(nm_keyfile['ipv4']['route1_options']).to eq('table=2505') }
+        it { expect(nm_keyfile['ipv4']['route2']).to eq('0.0.0.0/0,139.229.153.254') }
+        it { expect(nm_keyfile['ipv4']['route2_options']).to eq('table=2505') }
+        it { expect(nm_keyfile['ipv4']['routing-rule1']).to eq('priority 100 from 139.229.153.64/26 table 2505') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
       end
     end # on os
   end # on_supported_os


### PR DESCRIPTION
I'm assuming that the names for the dds interfaces will be auxtel-mcm-dds.ls.lsst.org and lsstcam-mcm-dds.ls.lsst.org,
consistent with eg the summit and Tucson, but the names don't seem to exist yet?
