### PR TITLE
(role/foreman) migrate foreman_envsync hub.docker.com -> ghcr.io

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -26,7 +26,7 @@ mod 'lsst/ccs_software', '1.3.0'
 mod 'lsst/cni', '2.4.1'
 mod 'lsst/daq', '1.3.0'
 mod 'lsst/dellperc', '1.3.0'
-mod 'lsst/foreman_envsync', '1.1.0'
+mod 'lsst/foreman_envsync', '1.2.0'
 mod 'lsst/helm_binary', '1.2.0'
 mod 'lsst/hosts', git: 'https://github.com/lsst-it/puppet-module-hosts', ref: '528475e' # Fork of ghoneycutt/hosts that includes https://github.com/ghoneycutt/puppet-module-hosts/pull/63
 mod 'lsst/java_artisanal', '2.4.0'

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -33,7 +33,7 @@ cron::job:
     weekday: "*"
     user: "root"
     description: "restart foreman to control memory bloat"
-foreman_envsync::image_tag: "v1.4.1"
+foreman_envsync::image_tag: "v1.5.1"
 r10k::mcollective: false
 r10k::cachedir: "/var/cache/r10k"
 r10k::sources:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -633,7 +633,9 @@ shared_examples 'generic foreman' do
 
   it { is_expected.to contain_foreman_hostgroup(site) }
 
-  it { is_expected.to contain_class('foreman_envsync') }
+  it do
+    is_expected.to contain_class('foreman_envsync').with_image_tag('v1.5.1')
+  end
 
   it do
     is_expected.to contain_class('r10k').with_postrun(


### PR DESCRIPTION
Depends on:
- https://github.com/lsst-it/foreman_envsync/pull/16
- https://github.com/lsst-it/foreman_envsync/pull/17
- https://github.com/lsst-it/foreman_envsync/pull/18
- https://github.com/lsst-it/foreman_envsync/pull/19
- https://github.com/lsst-it/puppet-foreman_envsync/pull/7
- https://github.com/lsst-it/puppet-foreman_envsync/pull/8