### PR TITLE
(role/foreman) fix foreman_envsync tag name

### DIFF
--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -33,7 +33,7 @@ cron::job:
     weekday: "*"
     user: "root"
     description: "restart foreman to control memory bloat"
-foreman_envsync::image_tag: "v1.5.1"
+foreman_envsync::image_tag: "1.5.1"
 r10k::mcollective: false
 r10k::cachedir: "/var/cache/r10k"
 r10k::sources:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -634,7 +634,7 @@ shared_examples 'generic foreman' do
   it { is_expected.to contain_foreman_hostgroup(site) }
 
   it do
-    is_expected.to contain_class('foreman_envsync').with_image_tag('v1.5.1')
+    is_expected.to contain_class('foreman_envsync').with_image_tag('1.5.1')
   end
 
   it do


### PR DESCRIPTION
The revised gha workflow is not creating the tag as `X.Y.Z` instead of `vX.Y.Z`.