### PR TITLE
(dimm.cp) add ts_dimm_app package

### DIFF
--- a/hieradata/role/dimm.yaml
+++ b/hieradata/role/dimm.yaml
@@ -1,46 +1,7 @@
-# The temporary DIMM server running on ESXi
 ---
-# See site/profile/manifests/core/common.pp
 classes:
-#  - chrony    # skipped: not strictly necessary right now, dimm has ntp configured
-#  - ssh       # skipped: too intrusive
-#  - sudo      # skipped: too intrusive, there's about 15 manual sudo entries for the DIMM user
-  - "accounts"
-  - "easy_ipa"
-  - "puppet_agent"
-  - "timezone"
+  - "profile::core::common"
+  - "profile::core::yum::lsst_ts_private"
 
-easy_ipa::install_sssd: true
-# attachmentgenie/ufw github repo is archived; mod needs updates. Not worth it
-# for a host which is supposed to be replaced.
-#ufw::allow:
-#  "dimm-webserver-16200":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16200"
-#  "dimm-webserver-16300":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16300"
-#  "dimm-webserver-16301":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16301"
-#  "dimm-webserver-16302":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16302"
-#  "dimm-webserver-16400":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16400"
-#  "dimm-webserver-16500":
-#    direction: "IN"
-#    from: "139.229.164.0/19"
-#    ip: "any"
-#    port: "16500"
+packages:
+  - 'ts_dimm_app-2.0-1.el8.x86_64'

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -21,11 +21,13 @@ describe "#{role} role" do
       end
 
       lsst_sites.each do |site|
-        # NOTE: that this role does not include profile::core::common
         describe "#{role}.#{site}.lsst.org", :site do
           let(:site) { site }
 
           it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('profile::core::common') }
+          it { is_expected.to contain_class('profile::core::yum::lsst_ts_private') }
+          it { is_expected.to contain_package('ts_dimm_app-2.0-1.el8.x86_64') }
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
ts_dimm_app package needed to be installed on the dimm server as requested on ticket IT-4384.
Old configuration for the VM dimm was wipe and the role was reestablish. 