### PR TITLE
(kueyen) Add support config for EL8

### DIFF
--- a/hieradata/cluster/kueyen.yaml
+++ b/hieradata/cluster/kueyen.yaml
@@ -1,29 +1,111 @@
 ---
 clustershell::groupmembers:
-  kueyen: {group: "kueyen", member: "kueyen[02-04]"}
-profile::core::rke::enable_dhcp: true
-profile::core::ifdown::interface: "em1"
+  kueyen: {group: "kueyen", member: "kueyen[01-03]"}
+cni::plugins::checksum: "f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37"
+cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "1.2.0"
+profile::core::common::manage_powertop: true
 profile::core::ospl::enable_rundir: true
-network::interfaces_hash:
-  em1:  # only for PXE
-    bootproto: "none"
-    onboot: "no"
-    type: "Ethernet"
-  p2p2:  # fqdn
-    bootproto: "dhcp"
-    defroute: "yes"
-    onboot: "yes"
-    type: "Ethernet"
-  p2p1:
-    bootproto: "none"
-    onboot: "no"
-    type: "Ethernet"
-  p2p1.2301:  # 139.229.145.0/24
-    bootproto: "dhcp"
-    defroute: "no"
-    nozeroconf: "yes"
-    onboot: "yes"
-    type: "none"
-    vlan: "yes"
-  p2p1.2400:  # 139.229.147.0/24
-    ensure: "absent"
+profile::core::rke::enable_dhcp: true
+profile::core::rke::version: "1.3.12"
+profile::nm::connections:
+  em1: #PXE Boot
+    content: |
+      [connection]
+      id=em1
+      uuid=f330f829-20cc-b829-67b0-18086a5fe6fa
+      type=ethernet
+      autoconnect=false
+      interface-name=em1
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  em2: #embedded 2 no use.
+    content: |
+      [connection]
+      id=em2
+      uuid=f330f829-20cc-b829-67b0-18086a5fe6fa
+      type=ethernet
+      autoconnect=false
+      interface-name=em2
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  ens2f1: #fqdn
+    content: |
+      [connection]
+      id=ens2f1
+      uuid=de9904c8-9577-1a17-36b1-34b94132f06a
+      type=ethernet
+      autoconnect=true
+      interface-name=ens2f1
+
+      [ethernet]
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      method=disabled
+  ens2f0:
+    content: |
+      [connection]
+      id=ens2f0
+      uuid=46d19ce1-bcab-7e77-6fc7-b730b26c54b1
+      type=ethernet
+      autoconnect=false
+      interface-name=ens2f0
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  ens2f0.2301:
+    content: |
+      [connection]
+      id=ens2f0.2301
+      uuid=e74daaad-4d73-4015-bb26-83c460ddf572
+      type=vlan
+      interface-name=ens2f0.2301
+      master=br2301
+      slave-type=bridge
+
+      [ethernet]
+
+      [vlan]
+      flags=1
+      id=2301
+      parent=ens2f0
+
+      [bridge-port]
+  br2301:
+    content: |
+      [connection]
+      id=br2301
+      uuid=7dd05d98-a9c3-4569-a7c3-00316b13c0eb
+      type=bridge
+      interface-name=br2301
+
+      [ethernet]
+
+      [bridge]
+      stp=false
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      method=disabled

--- a/hieradata/cluster/kueyen/role/rke.yaml
+++ b/hieradata/cluster/kueyen/role/rke.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - "profile::core::lhnrouting"
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false

--- a/spec/hosts/nodes/kueyen01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.ls.lsst.org_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'kueyen01.ls.lsst.org', :site do
+  alma8 = FacterDB.get_facts({ operatingsystem: 'AlmaLinux', operatingsystemmajrelease: '8' }).first
+  # rubocop:disable Naming/VariableNumber
+  { 'almalinux-8-x86_64': alma8 }.each do |os, facts|
+    # rubocop:enable Naming/VariableNumber
+    context "on #{os}" do
+      let(:facts) { override_facts(facts, fqdn: 'kueyen01.ls.lsst.org') }
+      let(:node_params) do
+        {
+          role: 'rke',
+          site: 'ls',
+          cluster: 'kueyen',
+        }
+      end
+      let(:vlan_id) { 2301 }
+      let(:rt_id) { vlan_id }
+
+      include_context 'with nm interface'
+
+      it { is_expected.to compile.with_all_deps }
+
+      it do
+        is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
+      end
+
+      it do
+        is_expected.to contain_class('clustershell').with(
+          groupmembers: {
+            'kueyen' => {
+              'group' => 'kueyen',
+              'member' => 'kueyen[01-03]',
+            },
+          },
+        )
+      end
+
+      it do
+        is_expected.to contain_class('profile::core::rke').with(
+          enable_dhcp: true,
+          version: '1.3.12',
+        )
+      end
+
+      it do
+        is_expected.to contain_class('cni::plugins').with(
+          version: '1.2.0',
+          checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
+          enable: ['macvlan'],
+        )
+      end
+
+      it { is_expected.to have_network__interface_resource_count(0) }
+      it { is_expected.to have_profile__nm__connection_resource_count(6) }
+
+      %w[
+        em1
+        em2
+      ].each do |i|
+        context "with #{name}" do
+          let(:interface) { i }
+
+          it_behaves_like 'nm disabled interface'
+        end
+      end
+
+      context 'with ens2f1' do
+        let(:interface) { 'ens2f1' }
+
+        it_behaves_like 'nm named interface'
+        it_behaves_like 'nm dhcp interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('ethernet') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be true }
+      end
+
+      context 'with ens2f0' do
+        let(:interface) { 'ens2f0' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('ethernet') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be false }
+      end
+
+      context 'with ens2f0.2301' do
+        let(:interface) { 'ens2f0.2301' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('vlan') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be_nil }
+        it { expect(nm_keyfile['connection']['master']).to eq('br2301') }
+        it { expect(nm_keyfile['connection']['slave-type']).to eq('bridge') }
+      end
+
+      context 'with br2301' do
+        let(:interface) { 'br2301' }
+
+        it_behaves_like 'nm named interface'
+        it { expect(nm_keyfile['connection']['type']).to eq('bridge') }
+        it { expect(nm_keyfile['connection']['autoconnect']).to be_nil }
+        it { expect(nm_keyfile['bridge']['stp']).to be false }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('auto') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
All the configuration for EL7 was removed and exchanged for network configuration compatible with EL8/9, plus some extra config for rke/clusters roles.