### PR TITLE
(cluster/comcam-ccs) revert removal of ccs publish.config.info

### DIFF
--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -74,6 +74,7 @@ ccs_sal::instrument: "%{lookup('ccs_instrument')}"
 
 ccs_software::global_properties:
   - "org.lsst.ccs.lockservice=remote"
+  - "org.lsst.ccs.config.publish.config.info=false"
   - "org.lsst.ccs.subsystem.agent.property.instrument=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.cluster=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"


### PR DESCRIPTION
This turned out to be premature.