### PR TITLE
(chonchon) correct vlan interface fix

### DIFF
--- a/hieradata/cluster/chonchon.yaml
+++ b/hieradata/cluster/chonchon.yaml
@@ -7,11 +7,11 @@ cni::plugins::version: "1.2.0"
 profile::core::common::manage_powertop: true
 profile::core::rke::enable_dhcp: true
 network::interfaces_hash:
-  eno2:  # trunk
+  em2:  # trunk
     bootproto: "none"
     onboot: "yes"
     type: "Ethernet"
-  eno2.1800:
+  em2.1800:
     bootproto: "none"
     defroute: "no"
     nozeroconf: "yes"

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -66,7 +66,7 @@ describe 'chonchon01.cp.lsst.org', :site do
       end
 
       it do
-        is_expected.to contain_network__interface("eno2.#{lhn_vlan_id}").with(
+        is_expected.to contain_network__interface("em2.#{lhn_vlan_id}").with(
           bootproto: 'none',
           defroute: 'no',
           nozeroconf: 'yes',


### PR DESCRIPTION
This fixes the mistake i made on the name of the interface for chonchon which is not called `eno2` but `em2`, Sorry =S
Tested and Working.