### PR TITLE
(dimm.cp) add NFS mount and telnet

### DIFF
--- a/hieradata/role/dimm.yaml
+++ b/hieradata/role/dimm.yaml
@@ -1,7 +1,16 @@
 ---
 classes:
   - "profile::core::common"
+  - "profile::core::nfsclient"
   - "profile::core::yum::lsst_ts_private"
 
 packages:
+  - 'telnet'
   - 'ts_dimm_app-2.0-1.el8.x86_64'
+
+nfs::client_enabled: true
+nfs::client_mounts:
+  /dimm:
+    share: "dimm"
+    server: "nfs1.cp.lsst.org"
+    atboot: true

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -28,6 +28,15 @@ describe "#{role} role" do
           it { is_expected.to contain_class('profile::core::common') }
           it { is_expected.to contain_class('profile::core::yum::lsst_ts_private') }
           it { is_expected.to contain_package('ts_dimm_app-2.0-1.el8.x86_64') }
+          it { is_expected.to contain_package('telnet') }
+
+          it do
+            is_expected.to contain_nfs__client__mount('/dimm').with(
+              share: 'dimm',
+              server: 'nfs1.cp.lsst.org',
+              atboot: true,
+            )
+          end
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
This adds the telnet package to the Dimm, but also sets the NFS mount requested in IT-4421.