### PR TITLE
(profile::core::perfsonar) rm perfSONAR yumrepo mirrorlist

### DIFF
--- a/site/profile/manifests/core/perfsonar.pp
+++ b/site/profile/manifests/core/perfsonar.pp
@@ -15,12 +15,13 @@ class profile::core::perfsonar (
   $le_root = "/etc/letsencrypt/live/${fqdn}"
 
   yumrepo { 'perfSONAR':
-    descr    => 'perfSONAR RPM Repository - software.internet2.edu - main',
-    baseurl  => "http://software.internet2.edu/rpms/el7/x86_64/${version}/",
-    enabled  => '1',
-    protect  => '0',
-    gpgkey   => 'http://software.internet2.edu/rpms/RPM-GPG-KEY-perfSONAR',
-    gpgcheck => '1',
+    descr      => 'perfSONAR RPM Repository - software.internet2.edu - main',
+    baseurl    => "http://software.internet2.edu/rpms/el7/x86_64/${version}/",
+    enabled    => '1',
+    protect    => '0',
+    gpgkey     => 'http://software.internet2.edu/rpms/RPM-GPG-KEY-perfSONAR',
+    gpgcheck   => '1',
+    mirrorlist => 'absent',
   }
 
   letsencrypt::certonly { $fqdn:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -825,6 +825,7 @@ shared_examples 'generic perfsonar' do
       protect: '0',
       gpgkey: 'http://software.internet2.edu/rpms/RPM-GPG-KEY-perfSONAR',
       gpgcheck: '1',
+      mirrorlist: 'absent',
     )
   end
 


### PR DESCRIPTION
The yumrepo type, by default, will not remove unmanaged parameters. The mirrorlist parameter must be explicitly set to 'absent' to remove it.