### PR TITLE
(profile::ccs::graphical) rm libvirt-daemon package

### DIFF
--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -23,6 +23,11 @@ class profile::ccs::graphical (
       unless  => 'sh -c "systemctl get-default | grep -qF graphical.target"',
     }
 
+    $unwanted_gnome_pkgs = [
+      'gnome-initial-setup',
+      'libvirt-daemon',  # rm unused virbr0[-nic] interfaces
+    ]
+
     ## Slow. Maybe better done separately?
     ## Don't want this on servers.
     ## Although people sometimes want to eg use vnc,
@@ -33,6 +38,7 @@ class profile::ccs::graphical (
       yum::group { 'GNOME Desktop':
         ensure  => present,
         timeout => 1800,
+        notify  => Package[$unwanted_gnome_pkgs],
       }
       yum::group { 'MATE Desktop':
         ensure  => present,
@@ -43,11 +49,12 @@ class profile::ccs::graphical (
       yum::group { 'Server with GUI':
         ensure  => present,
         timeout => 900,
+        notify  => Package[$unwanted_gnome_pkgs],
       }
       ensure_packages(['mate-desktop'])
     }
 
-    package { 'gnome-initial-setup':
+    package { $unwanted_gnome_pkgs:
       ensure => purged,
     }
 

--- a/spec/classes/ccs/graphical_spec.rb
+++ b/spec/classes/ccs/graphical_spec.rb
@@ -13,6 +13,11 @@ describe 'profile::ccs::graphical' do
             ensure: 'present',
             timeout: '1800',
           )
+                                                            .that_notifies('Package[gnome-initial-setup]')
+                                                            .that_notifies('Package[libvirt-daemon]')
+        end
+
+        it do
           is_expected.to contain_yum__group('MATE Desktop').with(
             ensure: 'present',
             timeout: '900',
@@ -24,8 +29,13 @@ describe 'profile::ccs::graphical' do
             ensure: 'present',
             timeout: '900',
           )
+                                                              .that_notifies('Package[gnome-initial-setup]')
+                                                              .that_notifies('Package[libvirt-daemon]')
         end
       end
+
+      it { is_expected.to contain_package('gnome-initial-setup').with_ensure('purged') }
+      it { is_expected.to contain_package('libvirt-daemon').with_ensure('purged') }
     end
   end
 end


### PR DESCRIPTION
The gnome-boxes package pulls in libvirt. This is results in both an unused running service and the creation bridge interfaces named `virbr0` (and `virbr0-nic` on EL7).