### PR TITLE
(role/ccs-dc) include profile::core::debugutils

### DIFF
--- a/hieradata/role/ccs-dc.yaml
+++ b/hieradata/role/ccs-dc.yaml
@@ -4,5 +4,6 @@ classes:
   - "profile::ccs::common"
   - "profile::ccs::graphical"
   - "profile::core::common"
+  - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::daq::daq_interface"

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -34,6 +34,7 @@ describe "#{role} role" do
             profile::ccs::common
             profile::ccs::graphical
             profile::core::common
+            profile::core::debugutils
             profile::core::nfsclient
             profile::daq::daq_interface
           ].each do |cls|


### PR DESCRIPTION
This provides useful utilities for debugging network configuration. E.g.: `bridge-utils`