### PR TITLE
(profile::daq::daq_interface) drop EL8+ support

### DIFF
--- a/hieradata/role/atsccs.yaml
+++ b/hieradata/role/atsccs.yaml
@@ -7,7 +7,6 @@ classes:
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
-  - "profile::daq::daq_interface"
 
 profile::core::systemd::tmpfile:
   docker_tmp.conf:  # XXX short term kludge

--- a/hieradata/role/atsccs/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/atsccs/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "profile::daq::daq_interface"

--- a/hieradata/role/atsdaq.yaml
+++ b/hieradata/role/atsdaq.yaml
@@ -7,7 +7,6 @@ classes:
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
-  - "profile::daq::daq_interface"
 
 profile::ccs::krb5_token::user: "ccs-ipa"
 profile::ccs::krb5_token::uid: 72055

--- a/hieradata/role/atsdaq/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/atsdaq/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "profile::daq::daq_interface"

--- a/hieradata/role/ccs-dc.yaml
+++ b/hieradata/role/ccs-dc.yaml
@@ -6,4 +6,3 @@ classes:
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
-  - "profile::daq::daq_interface"

--- a/hieradata/role/ccs-dc/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/ccs-dc/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "profile::daq::daq_interface"

--- a/hieradata/role/comcam-fp.yaml
+++ b/hieradata/role/comcam-fp.yaml
@@ -9,7 +9,6 @@ classes:
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
-  - "profile::daq::daq_interface"
 
 profile::ccs::krb5_token::user: "ccs-ipa"
 profile::ccs::krb5_token::uid: 72055

--- a/hieradata/role/comcam-fp/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/comcam-fp/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "profile::daq::daq_interface"

--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -10,7 +10,6 @@ classes:
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
   - "profile::daq::common"
-  - "profile::daq::daq_interface"
   - "profile::daq::sysctl"
   - "profile::nfs::v2"
 

--- a/hieradata/role/daq-mgt/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/daq-mgt/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "profile::daq::daq_interface"

--- a/spec/classes/daq/daq_interface_spec.rb
+++ b/spec/classes/daq/daq_interface_spec.rb
@@ -29,9 +29,9 @@ describe 'profile::daq::daq_interface' do
             )
           end
 
-          it { is_expected.to compile.with_all_deps }
-
           if facts[:os]['release']['major'] == '7'
+            it { is_expected.to compile.with_all_deps }
+
             it do
               is_expected.to contain_network__interface('lsst-daq').with(
                 hwaddr: 'aa:bb:cc:dd:ee:ff',
@@ -42,21 +42,11 @@ describe 'profile::daq::daq_interface' do
 
             it { is_expected.to contain_network__interface('eth1').with_ensure('absent') }
             it { is_expected.to contain_reboot('lsst-daq') }
+            it { is_expected.to contain_file('/etc/NetworkManager/dispatcher.d/30-ethtool') }
           else
             # el8+
-            let(:interface) { 'lsst-daq' }
-            include_context 'with nm interface'
-            include_examples 'nm named interface'
-            include_examples 'nm dhcp interface'
-            it { expect(nm_keyfile['connection']['uuid']).to eq(params[:uuid]) }
-            it { expect(nm_keyfile['ethernet']['mac-address']).to eq(params[:hwaddr]) }
-
-            it do
-              is_expected.to contain_profile__nm__connection('eth1').with_ensure('absent')
-            end
+            it { is_expected.to compile.and_raise_error(%r{unsupported on EL8+}) }
           end
-
-          it { is_expected.to contain_file('/etc/NetworkManager/dispatcher.d/30-ethtool') }
         end
       end
 
@@ -74,9 +64,9 @@ describe 'profile::daq::daq_interface' do
             )
           end
 
-          it { is_expected.to compile.with_all_deps }
-
           if facts[:os]['release']['major'] == '7'
+            it { is_expected.to compile.with_all_deps }
+
             it do
               is_expected.to contain_network__interface('lsst-daq').with(
                 hwaddr: 'aa:bb:cc:dd:ee:ff',
@@ -89,23 +79,11 @@ describe 'profile::daq::daq_interface' do
 
             it { is_expected.to contain_network__interface('eth1').with_ensure('absent') }
             it { is_expected.to contain_reboot('lsst-daq') }
+            it { is_expected.to contain_file('/etc/NetworkManager/dispatcher.d/30-ethtool') }
           else
             # el8+
-            let(:interface) { 'lsst-daq' }
-            include_context 'with nm interface'
-            include_examples 'nm named interface'
-            it { expect(nm_keyfile['connection']['uuid']).to eq(params[:uuid]) }
-            it { expect(nm_keyfile['ethernet']['mac-address']).to eq(params[:hwaddr]) }
-            it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
-            it { expect(nm_keyfile['ipv4']['address1']).to eq('192.168.100.1/24') }
-            it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
-
-            it do
-              is_expected.to contain_profile__nm__connection('eth1').with_ensure('absent')
-            end
+            it { is_expected.to compile.and_raise_error(%r{unsupported on EL8+}) }
           end
-
-          it { is_expected.to contain_file('/etc/NetworkManager/dispatcher.d/30-ethtool') }
         end
       end
     end

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -36,7 +36,6 @@ describe "#{role} role" do
             profile::core::common
             profile::core::debugutils
             profile::core::nfsclient
-            profile::daq::daq_interface
           ].each do |cls|
             it { is_expected.to contain_class(cls) }
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -324,11 +324,6 @@ shared_examples 'lsst-daq client' do |facts:|
         bootproto: 'dhcp',
       )
     end
-  else
-    let(:interface) { 'lsst-daq' }
-    include_context 'with nm interface'
-    include_examples 'nm named interface'
-    include_examples 'nm dhcp interface'
   end
 end
 


### PR DESCRIPTION
This reverts the EL8 support from the `profile::daq::daq_interface` class as we have already decided not to continue to use this approach for configuring daq interfaces under EL8.

Split out of #790 