### PR TITLE
(role/dimm) fix file/dir ownership; fix serial device ownership

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -69,6 +69,9 @@ lookup_options:
     merge:
       strategy: "deep"
       knockout_prefix: "--"
+  systemd::udev_rules:
+    merge:
+      strategy: "deep"
 
 hosts::purge_hosts: true
 timezone::timezone: "UTC"
@@ -412,3 +415,5 @@ nfs::nfs_v4_idmap_domain: "%{::domain}"
 profile::ccs::common::pkgurl: "https://repo-nexus.lsst.org/nexus/repository/ccs_private"
 ccs_hcu::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
 ccs_monit::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
+
+systemd::manage_udevd: true

--- a/hieradata/role/dimm.yaml
+++ b/hieradata/role/dimm.yaml
@@ -14,3 +14,10 @@ nfs::client_mounts:
     share: "dimm"
     server: "nfs1.cp.lsst.org"
     atboot: true
+
+systemd::udev_rules:
+  dimm_usb_devices.rules:
+    rules:
+      - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", GROUP="users"'
+      - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", GROUP="users"'
+      - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", GROUP="users"'

--- a/hieradata/role/dimm.yaml
+++ b/hieradata/role/dimm.yaml
@@ -21,3 +21,15 @@ systemd::udev_rules:
       - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", GROUP="users"'
       - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", GROUP="users"'
       - 'SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", GROUP="users"'
+
+files:
+  /opt/dimm: &dimm
+    owner: 79518
+    group: 'users'
+    recurse: true
+  /opt/Vimba_2_1:
+    <<: *dimm
+  /opt/astelos:
+    <<: *dimm
+  /mnt/dimm:
+    <<: *dimm

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -25,7 +25,8 @@ describe "#{role} role" do
           let(:site) { site }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('profile::core::common') }
+
+          include_examples 'common', facts: facts
           it { is_expected.to contain_class('profile::core::yum::lsst_ts_private') }
           it { is_expected.to contain_package('ts_dimm_app-2.0-1.el8.x86_64') }
           it { is_expected.to contain_package('telnet') }

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -38,6 +38,16 @@ describe "#{role} role" do
               atboot: true,
             )
           end
+
+          it do
+            is_expected.to contain_systemd__udev__rule('dimm_usb_devices.rules').with(
+              rules: [
+                'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", GROUP="users"',
+                'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", GROUP="users"',
+                'SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", GROUP="users"',
+              ],
+            )
+          end
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -48,6 +48,21 @@ describe "#{role} role" do
               ],
             )
           end
+
+          %w[
+            /opt/dimm
+            /opt/Vimba_2_1
+            /opt/astelos
+            /mnt/dimm
+          ].each do |d|
+            it do
+              is_expected.to contain_file(d).with(
+                owner: 79_518,
+                group: 'users',
+                recurse: true,
+              )
+            end
+          end
         end # host
       end # lsst_sites
     end # on os

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -249,6 +249,8 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true, network: true
       force: true,
     )
   end
+
+  it { is_expected.to contain_class('systemd').with_manage_udevd(true) }
 end
 
 shared_examples 'lhn sysctls', :lhn_node do


### PR DESCRIPTION
Fixes two issues observed on `dimm.cp.lsst.org`:

* The assorted dimm related services are running as `dimm:users`. This prevented them being able to create log files under the path `/mnt/dimm`, as those dirs were created by the rpm with a different `<uid>:<gid>`.
* Several of the dimm daemons are also trying to open `/dev/ttyUSB[012]`. By default, serial device ttys are owned `root:dialout`. As none of the running services where in the `dialout` group, they were unable to open these files.