### PR TITLE
(cluster/ruka) rke version bump 1.4.6-rc4

### DIFF
--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -6,7 +6,7 @@ cni::plugins::enable: ["macvlan"]
 cni::plugins::version: "1.2.0"
 profile::core::common::manage_powertop: true
 profile::core::rke::enable_dhcp: true
-profile::core::rke::version: "1.3.12"
+profile::core::rke::version: "1.4.6-rc4"
 network::interfaces_hash:
   br2505:
     bootproto: "none"

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -58,7 +58,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('profile::core::rke').with(
           enable_dhcp: true,
-          version: '1.3.12',
+          version: '1.4.6-rc4',
         )
       end
 


### PR DESCRIPTION
This add support to update the current rke version to 1.4.5 so we can move k8s version to 1.25.9 on ruka atm.