### PR TITLE
(profile::ccs::graphical) rm cockpit packages from `Server with GUI`

### DIFF
--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -26,6 +26,13 @@ class profile::ccs::graphical (
     $unwanted_gnome_pkgs = [
       'gnome-initial-setup',
       'libvirt-daemon',  # rm unused virbr0[-nic] interfaces
+      'cockpit',
+      'cockpit-bridge',
+      'cockpit-storaged',
+      'cockpit-ws',
+      'cockpit-packagekit',
+      'cockpit-podman',  # does not exist on el7
+      'cockpit-system',
     ]
 
     ## Slow. Maybe better done separately?


### PR DESCRIPTION
This will remove the `motd` file which causes the irritating cockpit message when logging into servers with the dnf `Server with GUI` group installed. E.g.:

```bash
 ~ $ ssh lsstcam-dc01.ls.lsst.org
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Thu May  4 17:00:41 2023 from 198.19.2.2
```