### PR TITLE
(profile::core::remote_desktop) rm class -- unused

### DIFF
--- a/site/profile/manifests/core/remote_desktop.pp
+++ b/site/profile/manifests/core/remote_desktop.pp
@@ -1,9 +1,0 @@
-# @summary
-#   Provide remote desktop services for GUI applications.
-class profile::core::remote_desktop {
-  include mate
-  class { 'x2go':
-    client => false,
-    server => true,
-  }
-}


### PR DESCRIPTION
This class is unused, the puppet mod it depends on isn't listed in the Puppetfile, and there are no tests for it.