### PR TITLE
(profile::core::x2go) fix sudo error; consolidate x2go package installation

### DIFF
--- a/hieradata/role/bastion.yaml
+++ b/hieradata/role/bastion.yaml
@@ -4,7 +4,7 @@
 classes:
   - "mate"
   - "profile::core::common"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"
 packages:
   - "rsync"
   - "tmux"

--- a/hieradata/role/bastion.yaml
+++ b/hieradata/role/bastion.yaml
@@ -2,6 +2,7 @@
 # point to otherwise isolated networks.
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::x2go_agent"
 packages:

--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::docker"

--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -7,7 +7,7 @@ classes:
   - "profile::core::docker::compose"
   - "profile::core::docker::prune"
   - "profile::core::ni_packages"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"
   - "profile::ts::nexusctio"
 files:
   /rubin:

--- a/hieradata/role/hvac.yaml
+++ b/hieradata/role/hvac.yaml
@@ -1,4 +1,5 @@
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::x2go_agent"

--- a/hieradata/role/hvac.yaml
+++ b/hieradata/role/hvac.yaml
@@ -2,4 +2,4 @@
 classes:
   - "mate"
   - "profile::core::common"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"

--- a/hieradata/role/m1m3.yaml
+++ b/hieradata/role/m1m3.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::x2go_agent"

--- a/hieradata/role/m1m3.yaml
+++ b/hieradata/role/m1m3.yaml
@@ -3,7 +3,7 @@ classes:
   - "mate"
   - "profile::core::common"
   - "profile::core::debugutils"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"
 
 packages:
   - "catch-devel"

--- a/hieradata/role/m2.yaml
+++ b/hieradata/role/m2.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::ni_packages"

--- a/hieradata/role/m2.yaml
+++ b/hieradata/role/m2.yaml
@@ -4,5 +4,5 @@ classes:
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::ni_packages"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"
   - "profile::ts::opensplicedds"

--- a/hieradata/role/net-dx.yaml
+++ b/hieradata/role/net-dx.yaml
@@ -3,4 +3,4 @@ classes:
   - "mate"
   - "profile::core::common"
   - "profile::core::net_dx"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"

--- a/hieradata/role/net-dx.yaml
+++ b/hieradata/role/net-dx.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "mate"
   - "profile::core::common"
   - "profile::core::net_dx"
   - "profile::core::x2go_agent"

--- a/hieradata/role/sal-dx.yaml
+++ b/hieradata/role/sal-dx.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "mate"
   - "profile::ccs::sal_dx"
   - "profile::core::common"
   - "profile::core::net_dx"

--- a/hieradata/role/sal-dx.yaml
+++ b/hieradata/role/sal-dx.yaml
@@ -4,4 +4,4 @@ classes:
   - "profile::ccs::sal_dx"
   - "profile::core::common"
   - "profile::core::net_dx"
-  - "profile::core::x2go_agent"
+  - "profile::core::x2go"

--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -11,6 +11,8 @@ class profile::ccs::graphical (
   Boolean $officeapps = false,
 ) {
   if $install {
+    include profile::core::x2go
+
     ensure_packages(['gdm'])
 
     service { 'gdm':
@@ -64,8 +66,6 @@ class profile::ccs::graphical (
     package { $unwanted_gnome_pkgs:
       ensure => purged,
     }
-
-    ensure_packages(['x2goclient', 'x2goserver', 'x2godesktopsharing'])
 
     ensure_packages(['icewm'])
   }

--- a/site/profile/manifests/core/x2go.pp
+++ b/site/profile/manifests/core/x2go.pp
@@ -1,7 +1,6 @@
 # @summary
 #   Adds additional packages for x2go agent
-
-class profile::core::x2go_agent {
+class profile::core::x2go {
   ensure_packages([
       'x2goserver',
       'x2goclient',

--- a/site/profile/manifests/core/x2go.pp
+++ b/site/profile/manifests/core/x2go.pp
@@ -8,4 +8,13 @@ class profile::core::x2go {
       'x2goserver-xsession',
       'x2goagent',
   ])
+
+  # the rpm set mode for this file is 644, which upsets the visudo command
+  file { '/etc/sudoers.d/x2goserver':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    require => Package['x2goserver'],
+  } -> Sudo::Conf <||>
 }

--- a/site/profile/manifests/core/x2go.pp
+++ b/site/profile/manifests/core/x2go.pp
@@ -2,11 +2,12 @@
 #   Adds additional packages for x2go agent
 class profile::core::x2go {
   ensure_packages([
-      'x2goserver',
+      'x2goagent',
       'x2goclient',
+      'x2godesktopsharing',
+      'x2goserver',
       'x2goserver-common',
       'x2goserver-xsession',
-      'x2goagent',
   ])
 
   # the rpm set mode for this file is 644, which upsets the visudo command

--- a/site/profile/manifests/core/x2go_agent.pp
+++ b/site/profile/manifests/core/x2go_agent.pp
@@ -2,7 +2,6 @@
 #   Adds additional packages for x2go agent
 
 class profile::core::x2go_agent {
-  include mate
   ensure_packages([
       'x2goserver',
       'x2goclient',

--- a/spec/classes/ccs/graphical_spec.rb
+++ b/spec/classes/ccs/graphical_spec.rb
@@ -20,6 +20,10 @@ describe 'profile::ccs::graphical' do
         ]
       end
 
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'x2go packages'
+
       if facts[:os]['release']['major'] == '7'
         it do
           unwanted_pkgs.each do |pkg|

--- a/spec/classes/core/x2go_agent_spec.rb
+++ b/spec/classes/core/x2go_agent_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::x2go_agent' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with no parameters' do
+        it { is_expected.to compile.with_all_deps }
+
+        include_examples 'x2go packages'
+      end
+    end
+  end
+end

--- a/spec/classes/core/x2go_spec.rb
+++ b/spec/classes/core/x2go_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'profile::core::x2go_agent' do
+describe 'profile::core::x2go' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do

--- a/spec/classes/core/x2go_spec.rb
+++ b/spec/classes/core/x2go_spec.rb
@@ -8,11 +8,22 @@ describe 'profile::core::x2go' do
       let(:facts) do
         facts
       end
+      let(:pre_condition) do
+        <<~PP
+        sudo::conf { 'bogus':
+          content => '%foo ALL=(bar) NOPASSWD: ALL',
+        }
+        PP
+      end
 
       context 'with no parameters' do
         it { is_expected.to compile.with_all_deps }
 
         include_examples 'x2go packages'
+        it do
+          is_expected.to contain_file('/etc/sudoers.d/x2goserver')
+            .that_comes_before('Sudo::Conf[bogus]')
+        end
       end
     end
   end

--- a/spec/hosts/roles/atshcu_spec.rb
+++ b/spec/hosts/roles/atshcu_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'atshcu'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          it { is_expected.to contain_class('ccs_hcu') }
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/atshcu_spec.rb
+++ b/spec/hosts/roles/atshcu_spec.rb
@@ -27,6 +27,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
           it { is_expected.to contain_class('ccs_hcu') }
         end # host
       end # lsst_sites

--- a/spec/hosts/roles/bastion_spec.rb
+++ b/spec/hosts/roles/bastion_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
 
           %w[
             rsync

--- a/spec/hosts/roles/bastion_spec.rb
+++ b/spec/hosts/roles/bastion_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'bastion'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          include_examples 'x2go packages'
+
+          %w[
+            rsync
+            tmux
+          ].each do |pkg|
+            it do
+              is_expected.to contain_package(pkg)
+            end
+          end
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -28,11 +28,11 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
 
           %w[
             ccs_daq
             profile::ccs::common
-            profile::ccs::graphical
             profile::core::common
             profile::core::debugutils
             profile::core::nfsclient

--- a/spec/hosts/roles/ccs_desktop_spec.rb
+++ b/spec/hosts/roles/ccs_desktop_spec.rb
@@ -27,6 +27,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/ccs_desktop_spec.rb
+++ b/spec/hosts/roles/ccs_desktop_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'ccs-desktop'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/ccs_hcu_spec.rb
+++ b/spec/hosts/roles/ccs_hcu_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'ccs-hcu'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          include_examples 'x2go packages'
+          it { is_expected.to contain_class('ccs_hcu') }
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/ccs_mcm_spec.rb
+++ b/spec/hosts/roles/ccs_mcm_spec.rb
@@ -33,6 +33,7 @@ describe "#{role} role" do
               it { is_expected.to compile.with_all_deps }
 
               include_examples 'common', facts: facts
+              include_examples 'x2go packages'
             end # host
           end # lsst_sites
         end # cluster

--- a/spec/hosts/roles/ccs_viswork_spec.rb
+++ b/spec/hosts/roles/ccs_viswork_spec.rb
@@ -27,6 +27,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/ccs_viswork_spec.rb
+++ b/spec/hosts/roles/ccs_viswork_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'ccs-viswork'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/comcam_fp_spec.rb
+++ b/spec/hosts/roles/comcam_fp_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
 
           case site
           when 'tu', 'cp'

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -27,6 +27,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
 
           # XXX hexrot uses devicemapper, so the docker example group isn't included
           it { is_expected.to contain_class('docker') }
@@ -37,7 +38,6 @@ describe "#{role} role" do
             profile::core::docker
             profile::core::docker::prune
             profile::core::ni_packages
-            profile::core::x2go_agent
           ].each do |c|
             it { is_expected.to contain_class(c) }
           end

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
 
           # XXX hexrot uses devicemapper, so the docker example group isn't included
           it { is_expected.to contain_class('docker') }

--- a/spec/hosts/roles/hvac_spec.rb
+++ b/spec/hosts/roles/hvac_spec.rb
@@ -27,6 +27,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/hvac_spec.rb
+++ b/spec/hosts/roles/hvac_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/m1m3_spec.rb
+++ b/spec/hosts/roles/m1m3_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'm1m3'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
+
+          %w[
+            catch-devel
+            yaml-cpp-devel
+          ].each do |pkg|
+            it do
+              is_expected.to contain_package(pkg)
+            end
+          end
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/m2_spec.rb
+++ b/spec/hosts/roles/m2_spec.rb
@@ -27,10 +27,10 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
+          include_examples 'x2go packages', facts: facts
           it { is_expected.to contain_class('profile::core::common') }
           it { is_expected.to contain_class('profile::core::debugutils') }
           it { is_expected.to contain_class('profile::core::ni_packages') }
-          it { is_expected.to contain_class('profile::core::x2go_agent') }
           it { is_expected.to contain_class('profile::ts::opensplicedds') }
           it { is_expected.to contain_yumrepo('lsst-ts-private') }
 

--- a/spec/hosts/roles/m2_spec.rb
+++ b/spec/hosts/roles/m2_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages', facts: facts
+          it { is_expected.to contain_class('mate') }
           it { is_expected.to contain_class('profile::core::common') }
           it { is_expected.to contain_class('profile::core::debugutils') }
           it { is_expected.to contain_class('profile::core::ni_packages') }

--- a/spec/hosts/roles/net_dx_spec.rb
+++ b/spec/hosts/roles/net_dx_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'net-dx'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          include_examples 'x2go packages'
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/roles/net_dx_spec.rb
+++ b/spec/hosts/roles/net_dx_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/sal_dx_spec.rb
+++ b/spec/hosts/roles/sal_dx_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'x2go packages'
+          it { is_expected.to contain_class('mate') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/sal_dx_spec.rb
+++ b/spec/hosts/roles/sal_dx_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+role = 'sal-dx'
+
+describe "#{role} role" do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: self.class.description,
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: role,
+          site: site,
+        }
+      end
+
+      lsst_sites.each do |site|
+        describe "#{role}.#{site}.lsst.org", :site do
+          let(:site) { site }
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'common', facts: facts
+          include_examples 'x2go packages'
+        end # host
+      end # lsst_sites
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -922,8 +922,6 @@ shared_examples 'generic perfsonar' do
 end
 
 shared_examples 'x2go packages' do
-  it { is_expected.to contain_class('mate') }
-
   %w[
     x2goserver
     x2goclient

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -921,4 +921,18 @@ shared_examples 'generic perfsonar' do
   end
 end
 
+shared_examples 'x2go packages' do
+  it { is_expected.to contain_class('mate') }
+
+  %w[
+    x2goserver
+    x2goclient
+    x2goserver-common
+    x2goserver-xsession
+    x2goagent
+  ].each do |pkg|
+    it { is_expected.to contain_package(pkg) }
+  end
+end
+
 # 'spec_overrides' from sync.yml will appear below this line

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -931,6 +931,15 @@ shared_examples 'x2go packages' do
   ].each do |pkg|
     it { is_expected.to contain_package(pkg) }
   end
+
+  it do
+    is_expected.to contain_file('/etc/sudoers.d/x2goserver').with(
+      ensure: 'file',
+      owner: 'root',
+      group: 'root',
+      mode: '0440',
+    ).that_requires('Package[x2goserver]')
+  end
 end
 
 # 'spec_overrides' from sync.yml will appear below this line

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -923,11 +923,12 @@ end
 
 shared_examples 'x2go packages' do
   %w[
-    x2goserver
+    x2goagent
     x2goclient
+    x2godesktopsharing
+    x2goserver
     x2goserver-common
     x2goserver-xsession
-    x2goagent
   ].each do |pkg|
     it { is_expected.to contain_package(pkg) }
   end


### PR DESCRIPTION
Resolves the `sudo::conf` resources errors caused by having a sudo config file with the wrong mode.
```
Notice: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/File[10_lsstcam_ccs_cmd]/ensure: defined content as '{sha256}436dfbf7916ba677a3a574507bf9c9e8e52dc5ea0b801fb3bd11dd5905b0deb9' (corrective)
Info: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/File[10_lsstcam_ccs_cmd]: Scheduling refresh of Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]
Notice: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]/returns: /etc/sudoers.d/x2goserver: bad permissions, should be mode 0440
Notice: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]/returns: /etc/sudoers: parsed OK
Notice: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]/returns: /etc/sudoers.d/10_lsstcam_ccs_cmd: parsed OK
Error: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]: Failed to call refresh: 'visudo -c || ( rm -f '/etc/sudoers.d/10_lsstcam_ccs_cmd' && exit 1)' returned 1 instead of one of [0]
Error: /Stage[main]/Sudo/Sudo::Conf[lsstcam_ccs_cmd]/Exec[sudo-syntax-check for file /etc/sudoers.d/10_lsstcam_ccs_cmd]: 'visudo -c || ( rm -f '/etc/sudoers.d/10_lsstcam_ccs_cmd' && exit 1)' returned 1 instead of one of [0]
Info: Sudo::Conf[lsstcam_ccs_cmd]: Unscheduling all events on Sudo::Conf[lsstcam_ccs_cmd]
```