### PR TITLE
(ccs) use lockmanager on all auxtel hosts

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -137,6 +137,7 @@ ccs_sal::dds_interface: "auxtel-mcm-dds.cp.lsst.org"
 ccs_sal::instrument: "%{lookup('ccs_instrument')}"
 
 ccs_software::global_properties:
+  - "org.lsst.ccs.lockservice=remote"
   - "org.lsst.ccs.subsystem.agent.property.instrument=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.cluster=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"

--- a/hieradata/node/auxtel-mcm.ls.lsst.org.yaml
+++ b/hieradata/node/auxtel-mcm.ls.lsst.org.yaml
@@ -8,6 +8,7 @@ ccs_software::services:
     - "mmm"
     - "cluster-monitor"
     - "localdb"
+    - "lockmanager"
     - "rest-server"
 
 nfs::client_enabled: true

--- a/hieradata/site/cp/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/cp/cluster/auxtel-ccs.yaml
@@ -1,5 +1,2 @@
 ---
-ccs_software::global_properties:
-  - "org.lsst.ccs.lockservice=remote"
-
 daq::daqsdk::version: "R5-V6.1"

--- a/hieradata/site/tu/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/tu/cluster/auxtel-ccs.yaml
@@ -2,9 +2,6 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "auxtel-mcm-dds.tu.lsst.org"
 
-ccs_software::global_properties:
-  - "org.lsst.ccs.lockservice=remote"
-
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 
 ccs_monit::alert:


### PR DESCRIPTION
Since it was already active on TTS and summit, this is adding BTS.
