### PR TITLE
(node/auxtel-archiver.{tu,cp}.lsst.org) rm /data/allsky nfs export

### DIFF
--- a/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
@@ -97,14 +97,6 @@ nfs::nfs_exports_global:
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.175.128/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
-  /data/allsky:
-    clients: >-
-      %{facts.networking.ip}/32(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)
 
 nfs::client_enabled: true
 nfs::client_mounts:
@@ -119,10 +111,6 @@ nfs::client_mounts:
     atboot: true
   /net/self/data/root:  # don't mount "data" at root of other exports
     share: "data"
-    server: "%{facts.fqdn}"
-    atboot: true
-  /net/self/data/allsky:
-    share: "allsky"
     server: "%{facts.fqdn}"
     atboot: true
   # remote mounts

--- a/hieradata/node/auxtel-archiver.tu.lsst.org.yaml
+++ b/hieradata/node/auxtel-archiver.tu.lsst.org.yaml
@@ -61,11 +61,6 @@ nfs::nfs_exports_global:
       %{facts.networking.ip}/32(rw,nohide,insecure,no_subtree_check,async,root_squash)
       140.252.147.64/27(rw,nohide,insecure,no_subtree_check,async,root_squash)
       140.252.146.32/27(rw,nohide,insecure,no_subtree_check,async,root_squash)
-  /data/allsky:
-    clients: >-
-      %{facts.networking.ip}/32(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      140.252.147.64/27(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      140.252.146.32/27(rw,nohide,insecure,no_subtree_check,async,root_squash)
 
 nfs::client_enabled: true
 nfs::client_mounts:
@@ -79,10 +74,6 @@ nfs::client_mounts:
     atboot: true
   /net/self/data/root:  # don't mount "data" at root of other exports
     share: "data"
-    server: "%{facts.fqdn}"
-    atboot: true
-  /net/self/data/allsky:
-    share: "allsky"
     server: "%{facts.fqdn}"
     atboot: true
 

--- a/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
@@ -92,7 +92,6 @@ describe 'auxtel-archiver.cp.lsst.org', :site do
       it { is_expected.to contain_nfs__server__export('/data/lsstdata') }
       it { is_expected.to contain_nfs__server__export('/data/repo') }
       it { is_expected.to contain_nfs__server__export('/data') }
-      it { is_expected.to contain_nfs__server__export('/data/allsky') }
 
       it do
         is_expected.to contain_nfs__client__mount('/net/self/data/lsstdata').with(
@@ -113,14 +112,6 @@ describe 'auxtel-archiver.cp.lsst.org', :site do
       it do
         is_expected.to contain_nfs__client__mount('/net/self/data/root').with(
           share: 'data',
-          server: 'auxtel-archiver.cp.lsst.org',
-          atboot: true,
-        )
-      end
-
-      it do
-        is_expected.to contain_nfs__client__mount('/net/self/data/allsky').with(
-          share: 'allsky',
           server: 'auxtel-archiver.cp.lsst.org',
           atboot: true,
         )

--- a/spec/hosts/nodes/auxtel-archiver.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-archiver.tu.lsst.org_spec.rb
@@ -114,14 +114,6 @@ describe 'auxtel-archiver.tu.lsst.org', :site do
           atboot: true,
         )
       end
-
-      it do
-        is_expected.to contain_nfs__client__mount('/net/self/data/allsky').with(
-          share: 'allsky',
-          server: 'auxtel-archiver.tu.lsst.org',
-          atboot: true,
-        )
-      end
     end # on os
   end # on_supported_os
 end # role


### PR DESCRIPTION
This nfs export was triggering a bug on auxtel-archiver.cp.lsst.org where when /data/allsky was exported as :/allsky, the :/data export would also become an export of /data/allsky.  As the :/data export already existed and had the same export client list as :/allsky, nfs client were already able to mount :/data/allsky.  It isn't known why this issue could not be reproduced on auxtel-archiver.tu.lsst.org nor as to why other exports of `/data/<sub dir>` do not trigger this issue.

The nfs-utils-1.3.0-mountd-root.patch patch included in nfs-utils-1.3.0-0.68.0.1.el7.2.src.rpm does not fix this issue.