### PR TITLE
(!site/cp) set docker::log_opt log size limits

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -225,7 +225,11 @@ accounts::user_list:
     <<: *rm_user
   hreinking_b:
     <<: *rm_user
-
+docker::log_driver: "json-file"
+docker::log_opt:
+  - "max-file=2"
+  - "max-size=50m"
+  - "mode=non-blocking"
 tuned::profile: "latency-performance"
 selinux::mode: "disabled"
 # Stop iptables by default - the default rules are highly restrictive to the

--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -1,4 +1,6 @@
 ---
+docker::log_driver: ~
+docker::log_opt: ~
 easy_ipa::ipa_master_fqdn: "ipa1.cp.lsst.org"
 # sssd ipa client setup -- do not use on ipa servers
 sssd::domains:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -498,6 +498,22 @@ shared_examples 'docker' do
       version: '2.17.3',
     )
   end
+
+  it do
+    # skip this example for class tests
+    next unless defined?(node_params)
+
+    to = node_params[:site] == 'cp' ? 'not_to' : 'to'
+
+    is_expected.send(to, contain_class('docker').with(
+                           log_driver: 'json-file',
+                           log_opt: %w[
+                             max-file=2
+                             max-size=50m
+                             mode=non-blocking
+                           ],
+                         ))
+  end
 end
 
 shared_examples 'rke profile' do


### PR DESCRIPTION
Manually tested as working:

```bash
[jhoblitt@jhoblitt-test2 ~]$ docker inspect -f '{{.HostConfig.LogConfig}}' dfa822be71014968df58075bac6f9605fb7b97c3e6d41950c3d558e1471ec6a7
{json-file map[max-file:2 max-size:50m mode:non-blocking]}
```