### PR TITLE
(gha) add arborist gha workflow

### DIFF
--- a/.arborist.yaml
+++ b/.arborist.yaml
@@ -1,0 +1,10 @@
+---
+# yamllint disable rule:quoted-strings
+noop: false
+repos:
+  - repo: lsst-it/lsst-control
+    noop: false
+  - repo: lsst-it/lsst-puppet-hiera-private
+    noop: false
+exclude_patterns:
+  - production

--- a/.github/workflows/arborist.yaml
+++ b/.github/workflows/arborist.yaml
@@ -1,0 +1,26 @@
+---
+# yamllint disable rule:quoted-strings
+name: Arborist
+
+"on":
+  - create
+  - delete
+  - pull_request
+  - push
+
+permissions:
+  contents: write
+
+jobs:
+  arborist:
+    name: Prune dead branches
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: run arborist
+        uses: jhoblitt/arborist-action@v1
+        with:
+          repo-token: "${{ secrets.ARBORIST_GITHUB_TOKEN }}"


### PR DESCRIPTION
Note that this workflow is dependent on a secret added to this repo named "ARBORIST_GITHUB_ACTION". This secret is a   fine grained personal access token, which will expire on 2024-06-06 and need to be replaced.