### PR TITLE
 (node/auxtel-archiver.cp.lsst.org) rm all NFS exports; mount nfs-auxtel:/auxtel

### DIFF
--- a/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
@@ -58,62 +58,8 @@ network::mroutes_hash:
     ensure: "absent"
     routes: {}
 
-# 139.229.146.0/24    antu
-# 139.229.160.0/24    cp general & yagan
-# 139.229.165.0/24    cp archive
-# 139.229.175.128/25  auxtel-ccs
-nfs::server_enabled: true
-nfs::nfs_v4_export_root_clients: >-
-  %{facts.networking.ip}/32(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.146.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.160.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.165.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.170.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.175.128/25(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
-nfs::nfs_exports_global:
-  /data/lsstdata:
-    clients: >-
-      %{facts.networking.ip}/32(ro,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.128/25(rw,nohide,insecure,no_subtree_check,async,root_squash)
-  /data/repo:
-    clients: >-
-      %{facts.networking.ip}/32(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.128/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
-  /data:
-    clients: >-
-      %{facts.networking.ip}/32(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)
-      139.229.175.128/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
-
 nfs::client_enabled: true
 nfs::client_mounts:
-  # sanity check mounts
-  /net/self/data/lsstdata:
-    share: "lsstdata"
-    server: "%{facts.fqdn}"
-    atboot: true
-  /repo:
-    share: "repo"
-    server: "%{facts.fqdn}"
-    atboot: true
-  /net/self/data/root:  # don't mount "data" at root of other exports
-    share: "data"
-    server: "%{facts.fqdn}"
-    atboot: true
-  # remote mounts
   /net/dimm:
     share: "dimm"
     server: "nfs1.cp.lsst.org"

--- a/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-archiver.cp.lsst.org.yaml
@@ -60,9 +60,9 @@ network::mroutes_hash:
 
 nfs::client_enabled: true
 nfs::client_mounts:
-  /net/dimm:
-    share: "dimm"
-    server: "nfs1.cp.lsst.org"
+  /data:
+    share: "auxtel"
+    server: "nfs-auxtel.cp.lsst.org"
     atboot: true
 
 profile::core::k5login::k5login:

--- a/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
@@ -88,35 +88,6 @@ describe 'auxtel-archiver.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
-      it { is_expected.to contain_class('nfs::server').with_nfs_v4(true) }
-      it { is_expected.to contain_nfs__server__export('/data/lsstdata') }
-      it { is_expected.to contain_nfs__server__export('/data/repo') }
-      it { is_expected.to contain_nfs__server__export('/data') }
-
-      it do
-        is_expected.to contain_nfs__client__mount('/net/self/data/lsstdata').with(
-          share: 'lsstdata',
-          server: 'auxtel-archiver.cp.lsst.org',
-          atboot: true,
-        )
-      end
-
-      it do
-        is_expected.to contain_nfs__client__mount('/repo').with(
-          share: 'repo',
-          server: 'auxtel-archiver.cp.lsst.org',
-          atboot: true,
-        )
-      end
-
-      it do
-        is_expected.to contain_nfs__client__mount('/net/self/data/root').with(
-          share: 'data',
-          server: 'auxtel-archiver.cp.lsst.org',
-          atboot: true,
-        )
-      end
-
       it do
         is_expected.to contain_nfs__client__mount('/net/dimm').with(
           share: 'dimm',

--- a/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-archiver.cp.lsst.org_spec.rb
@@ -89,9 +89,9 @@ describe 'auxtel-archiver.cp.lsst.org', :sitepp do
       it { is_expected.to compile.with_all_deps }
 
       it do
-        is_expected.to contain_nfs__client__mount('/net/dimm').with(
-          share: 'dimm',
-          server: 'nfs1.cp.lsst.org',
+        is_expected.to contain_nfs__client__mount('/data').with(
+          share: 'auxtel',
+          server: 'nfs-auxtel.cp.lsst.org',
           atboot: true,
         )
       end


### PR DESCRIPTION
The current `auxtel-archiver.cp.lsst.org` host has a bad CMOS battery and strange BIOS errors messages -- the host can no longer be trusted. This host dates from 2018 and support expired on `15 FEB 2023` and will be retired rather than repaired. The `/data` volume has been copied to `nfs-auxtel.cp.lsst.org:/auxtel` and all previous clients of `auxtel.archiver.cp` should already be updated to the new nfs export.  The host is being left in service temporarily as `ccs-ipa@auxtel-fp01.cp` is `scp`ing data to `/data`. In order to keep this process working, `nfs-auxtel.cp.lsst.org:/auxtel` is being mounted as `/data`.