### PR TITLE
(dev/role) set rke version 1.4.6-rc4

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::rke::version: "1.4.6-rc4"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -48,6 +48,7 @@ class profile::core::rke (
     '1.3.3'  => '61088847d80292f305e233b7dff4ac8e47fefdd726e5245052450bf05da844aa',
     '1.3.6'  => 'c02a8dd7405e3729e004bb1d551fda4c1437f5e0e8279ea67efba8056c0d4898',
     '1.3.12' => '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+    '1.4.6-rc4' => '220cdd575fcefc77ef8d7c2ff030cb8604fa484f7db5d3bcffa2cd6c794b2563',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -25,6 +25,7 @@ describe "#{role} role" do
   # rubocop:disable Naming/VariableNumber
   on_supported_os.merge('almalinux-9-x86_64': alma9).each do |os, facts|
     # rubocop:enable Naming/VariableNumber
+
     context "on #{os}" do
       let(:facts) { facts }
       let(:node_params) do
@@ -34,19 +35,85 @@ describe "#{role} role" do
         }
       end
 
-      lsst_sites.each do |site|
-        fqdn = "#{role}.#{site}.lsst.org"
+      fqdn = "#{role}.tu.lsst.org"
+      # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      describe fqdn, :sitepp do
+        # rubocop:enable RSpec/RepeatedExampleGroupDescription
         override_facts(facts, fqdn: fqdn, networking: { fqdn => fqdn })
+        let(:site) { 'tu' }
 
-        describe fqdn, :sitepp do
-          let(:site) { site }
+        it { is_expected.to compile.with_all_deps }
 
-          it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
 
-          include_examples 'common', facts: facts
-          include_examples 'generic rke'
-        end # host
-      end # lsst_sites
+        include_examples 'common', facts: facts
+        include_examples 'generic rke'
+      end # host
+
+      fqdn = "#{role}.ls.lsst.org"
+      # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      describe fqdn, :sitepp do
+        # rubocop:enable RSpec/RepeatedExampleGroupDescription
+        override_facts(facts, fqdn: fqdn, networking: { fqdn => fqdn })
+        let(:site) { 'ls' }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
+
+        include_examples 'common', facts: facts
+        include_examples 'generic rke'
+      end # host
+
+      fqdn = "#{role}.cp.lsst.org"
+      # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      describe fqdn, :sitepp do
+        # rubocop:enable RSpec/RepeatedExampleGroupDescription
+        override_facts(facts, fqdn: fqdn, networking: { fqdn => fqdn })
+        let(:site) { 'cp' }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
+
+        include_examples 'common', facts: facts
+        include_examples 'generic rke'
+      end # host
+
+      fqdn = "#{role}.dev.lsst.org"
+      # rubocop:disable RSpec/RepeatedExampleGroupDescription
+      describe fqdn, :sitepp do
+        # rubocop:enable RSpec/RepeatedExampleGroupDescription
+        override_facts(facts, fqdn: fqdn, networking: { fqdn => fqdn })
+        let(:site) { 'dev' }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.4.6-rc4',
+            checksum: '220cdd575fcefc77ef8d7c2ff030cb8604fa484f7db5d3bcffa2cd6c794b2563',
+          )
+        end
+
+        include_examples 'common', facts: facts
+        include_examples 'generic rke'
+      end # host
     end # on os
   end # on_supported_os
 end # role


### PR DESCRIPTION
we need to bump the version of the rke client in order to crank that cluster.yaml from lsst-it/k8s-cookbook#178 to version ```v1.25.9-rancher2-2``` that matches rancher v2.7.4