### PR TITLE
(cluster/auxtel-ccs, comcam-ccs) bump ts_sal version for cycle 31

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -153,7 +153,7 @@ ccs_software::udp_properties:
 
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.0.0-1.x86_64.rpm"
+  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
 
 daq::daqsdk::purge: false
 

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -60,7 +60,7 @@ ccs_database::database: "comcamdbprod"
 
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.0.0-1.x86_64.rpm"
+  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
 
 ## Used in lookups:
 ccs_site: "summit"

--- a/hieradata/site/cp/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/cp/cluster/auxtel-ccs.yaml
@@ -1,5 +1,2 @@
 ---
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
-
 daq::daqsdk::version: "R5-V6.1"

--- a/hieradata/site/cp/cluster/comcam-ccs.yaml
+++ b/hieradata/site/cp/cluster/comcam-ccs.yaml
@@ -1,5 +1,2 @@
 ---
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
-
 daq::daqsdk::version: "R5-V6.1"

--- a/hieradata/site/tu/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/tu/cluster/auxtel-ccs.yaml
@@ -2,9 +2,6 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "auxtel-mcm-dds.tu.lsst.org"
 
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
-
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 
 ccs_monit::alert:

--- a/hieradata/site/tu/cluster/comcam-ccs.yaml
+++ b/hieradata/site/tu/cluster/comcam-ccs.yaml
@@ -2,9 +2,6 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "comcam-mcm-dds.tu.lsst.org"
 
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
-
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 
 ccs_monit::alert:


### PR DESCRIPTION
This moves the setting from being tu and cp site-specific to global, ie also on the bts.