### PR TITLE
(foreman.ls) Rename Kueyen Network to Ayekan

### DIFF
--- a/hieradata/site/ls/role/foreman.yaml
+++ b/hieradata/site/ls/role/foreman.yaml
@@ -43,12 +43,12 @@ dhcp::pools:
     range:
       - "139.229.140.24 139.229.140.30"  # ~ /30
     search_domains: "%{alias('dhcp::dnsdomain')}"
-  TS-Kueyen:  # https://jira.lsstcorp.org/browse/IT-2128
+  BDC-Ayekan:
     network: "139.229.144.0"
-    mask: "255.255.255.128"
-    gateway: "139.229.144.126"
+    mask: "255.255.255.192"
+    gateway: "139.229.144.62"
     range:
-      - "139.229.144.100 139.229.144.120"
+      - "139.229.144.40 139.229.144.59"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   BDC-Teststand-DDS:  # vlan2301
     network: "139.229.145.0"

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -248,11 +248,11 @@ describe "#{role} role" do
         end
 
         it do
-          is_expected.to contain_dhcp__pool('TS-Kueyen').with(
+          is_expected.to contain_dhcp__pool('BDC-Ayekan').with(
             network: '139.229.144.0',
-            mask: '255.255.255.128',
-            range: ['139.229.144.100 139.229.144.120'],
-            gateway: '139.229.144.126',
+            mask: '255.255.255.192',
+            range: ['139.229.144.40 139.229.144.59'],
+            gateway: '139.229.144.62',
           )
         end
 


### PR DESCRIPTION
We are going to use the old network segment on Kueyen for the Observability Cluster Ayekan.