### PR TITLE
(cluster/pillan) add ip rules for br3035

### DIFF
--- a/hieradata/cluster/pillan/osfamily/RedHat/major/9.yaml
+++ b/hieradata/cluster/pillan/osfamily/RedHat/major/9.yaml
@@ -169,6 +169,11 @@ profile::nm::connections:
 
       [ipv4]
       method=disabled
+      route1=140.252.147.192/27
+      route1_options=table=3035
+      route2=0.0.0.0/0,140.252.147.193
+      route2_options=table=3035
+      routing-rule1=priority 100 from 140.252.147.192/27 table 3035
 
       [ipv6]
       method=disabled

--- a/hieradata/cluster/pillan/role/rke.yaml
+++ b/hieradata/cluster/pillan/role/rke.yaml
@@ -1,0 +1,4 @@
+---
+classes:
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -24,6 +24,10 @@ describe 'pillan08.tu.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      it do
+        is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
+      end
+
       # 2 extra instances in the catalog for the rename interfaces
       it { is_expected.to have_profile__nm__connection_resource_count(14 + 2) }
 

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -75,7 +75,6 @@ describe 'pillan08.tu.lsst.org', :sitepp do
       end
 
       %w[
-        br3035
         br3065
         br3065
         br3085
@@ -87,6 +86,20 @@ describe 'pillan08.tu.lsst.org', :sitepp do
           it_behaves_like 'nm bridge interface'
           it_behaves_like 'nm no-ip interface'
         end
+      end
+
+      context 'with br3035' do
+        let(:interface) { 'br3035' }
+        let(:vlan) { '3035' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm no-ip interface'
+        it_behaves_like 'nm bridge interface'
+        it { expect(nm_keyfile['ipv4']['route1']).to eq('140.252.147.192/27') }
+        it { expect(nm_keyfile['ipv4']['route1_options']).to eq("table=#{vlan}") }
+        it { expect(nm_keyfile['ipv4']['route2']).to eq('0.0.0.0/0,140.252.147.193') }
+        it { expect(nm_keyfile['ipv4']['route2_options']).to eq("table=#{vlan}") }
+        it { expect(nm_keyfile['ipv4']['routing-rule1']).to eq("priority 100 from 140.252.147.192/27 table #{vlan}") }
       end
     end # on os
   end # on_supported_os


### PR DESCRIPTION
As with on the manke cluster, I suspect the ip rules are not matching anything and are being bypassed by nftables, which is why disabling `rp_filter` is necessary.