### PR TITLE
(role/rke) fs.inotify.max_inotify_instances=104857

### DIFF
--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -65,4 +65,13 @@ class profile::core::rke (
     target => '/etc/sysctl.d/80-rke.conf',
   }
   -> Class['docker']
+
+  sysctl::value { 'fs.inotify.max_inotify_instances':
+    value  => 104857,
+    target => '/etc/sysctl.d/80-rke.conf',
+  }
+  sysctl::value { 'fs.inotify.max_inotify_watches':
+    value  => 1048576,
+    target => '/etc/sysctl.d/80-rke.conf',
+  }
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -598,6 +598,20 @@ shared_examples 'rke profile' do
   end
 
   it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_inotify_instances').with(
+      value: 104_857,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+
+  it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_inotify_watches').with(
+      value: 1_048_576,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+
+  it do
     is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook').that_requires('Class[easy_ipa]')
   end
 end


### PR DESCRIPTION
To resolve this error message from kubectl when tailing pod logs:

    failed to create fsnotify watcher: too many open files