### PR TITLE
It 4622/auxtel lsstcam software

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -140,5 +140,6 @@ ccs_sal::rpms:
   ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
 
 daq::daqsdk::purge: false
+daq::daqsdk::version: "R5-V6.7"
 
 hosts::stored_config: false

--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -86,34 +86,6 @@ accounts::user_list:
 ccs_software::desktop: true
 ccs_software::env: "AuxTel"
 ccs_software::installations:
-  ats-software-2.2.3:
-    aliases:
-      - "puppet-2.2.3"
-
-  ats-software-2.2.4:
-    aliases:
-      - "puppet-2.2.4"
-
-  ats-software-2.2.5:
-    aliases:
-      - "puppet-2.2.5"
-
-  ats-software-2.2.6:
-    aliases:
-      - "puppet-2.2.6"
-
-  ats-software-2.2.7:
-    aliases:
-      - "puppet-2.2.7"
-
-  ats-software-2.2.8:
-    aliases:
-      - "puppet-2.2.8"
-
-  ats-software-2.2.9:
-    aliases:
-      - "puppet-2.2.9"
-
   ats-software-2.2.10:
     aliases:
       - "puppet-2.2.10"
@@ -130,9 +102,17 @@ ccs_software::installations:
     aliases:
       - "puppet-2.2.14"
 
+  ats-software-2.2.15:
+    aliases:
+      - "puppet-2.2.15"
+
   ats-software-2.3.0:
     aliases:
       - "puppet-2.3.0"
+
+  ats-software-2.3.1:
+    aliases:
+      - "puppet-2.3.1"
 
 ## Used in lookups:
 ccs_site: "summit"

--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -118,6 +118,9 @@ ccs_software::installations:
   lsstcam-software-1.0.3:
     aliases:
       - "puppet-1.0.3"
+  lsstcam-software-1.0.4:
+    aliases:
+      - "puppet-1.0.4"
 
 # FIXME
 #profile::icinga::agent::host_template: "LSSTCamHostTemplate"

--- a/hieradata/site/cp/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/cp/cluster/auxtel-ccs.yaml
@@ -1,2 +1,0 @@
----
-daq::daqsdk::version: "R5-V6.1"

--- a/hieradata/site/ls/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/ls/cluster/auxtel-ccs.yaml
@@ -13,5 +13,3 @@ clustershell::groupmembers:
   #hcu: {group: "hcu", member: "auxtel-hcu01"}
   #all: {group: "all", member: "@misc,@hcu"}
   all: {group: "all", member: "@misc"}
-
-daq::daqsdk::version: "R5-V6.1"

--- a/hieradata/site/tu/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/tu/cluster/auxtel-ccs.yaml
@@ -10,5 +10,3 @@ ccs_monit::alert:
 
 clustershell::groupmembers:
   all: {group: "all", member: "auxtel-fp01,auxtel-mcm"}
-
-daq::daqsdk::version: "R5-V6.1"


### PR DESCRIPTION
This installs new CCS software releases for lsstcam and auxtel. This is a safe operation since it does not change the current "production" version. In addition this updates the DAQ installation on auxtel to R5-V6.7.