### PR TITLE
(role/daq-mgt) updated all DAQ to R5-V6.7

### DIFF
--- a/hieradata/node/auxtel-daq-mgt.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-daq-mgt.cp.lsst.org.yaml
@@ -4,7 +4,7 @@ profile::daq::daq_interface::uuid: "9129970c-d4b9-4602-82be-da776c06c064"
 profile::daq::daq_interface::was: "p3p1"
 profile::daq::daq_interface::mode: "dhcp-server"
 
-daq::daqsdk::version: "R5-V6.1"
+#daq::daqsdk::version: "R5-V6.7"
 
 network::interfaces_hash:
   em1:  # fqdn

--- a/hieradata/node/comcam-daq-mgt.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-daq-mgt.cp.lsst.org.yaml
@@ -4,7 +4,7 @@ profile::daq::daq_interface::uuid: "757b897b-0721-44b6-86fc-be1d86d144cd"
 profile::daq::daq_interface::was: "p2p1"
 profile::daq::daq_interface::mode: "dhcp-server"
 
-daq::daqsdk::version: "R5-V6.1"
+#daq::daqsdk::version: "R5-V6.7"
 
 network::interfaces_hash:
   em1:  # fqdn

--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V6.1"
+daq::daqsdk::version: "R5-V6.7"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients

--- a/hieradata/site/ls/role/daq-mgt.yaml
+++ b/hieradata/site/ls/role/daq-mgt.yaml
@@ -3,4 +3,4 @@ dhcp::dnsdomain: []  # ignore site value & mod default
 dhcp::nameservers: ~  # ignore site value
 dhcp::ntpservers: ~  # ignore site value
 
-daq::daqsdk::version: "R5-V6.7"
+#daq::daqsdk::version: "R5-V6.7"

--- a/hieradata/site/tu/role/daq-mgt.yaml
+++ b/hieradata/site/tu/role/daq-mgt.yaml
@@ -3,4 +3,4 @@ dhcp::dnsdomain: []  # ignore site value & mod default
 dhcp::nameservers: ~  # ignore site value
 dhcp::ntpservers: ~  # ignore site value
 
-daq::daqsdk::version: "R5-V6.1"
+#daq::daqsdk::version: "R5-V6.7"

--- a/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
@@ -30,7 +30,7 @@ describe 'auxtel-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_network__interface('p3p1').with_ensure('absent') }
 

--- a/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
@@ -30,7 +30,7 @@ describe 'comcam-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }
 

--- a/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
@@ -30,7 +30,7 @@ describe 'daq-mgt.tu.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }
 


### PR DESCRIPTION
Moves the AuxTel and ComCam DAQ versions forward to R5-V6.7