### PR TITLE
(ayekan.ls) Initial network config and role

### DIFF
--- a/hieradata/cluster/ayekan.yaml
+++ b/hieradata/cluster/ayekan.yaml
@@ -1,0 +1,90 @@
+---
+clustershell::groupmembers:
+  ayekan: {group: "ayekan", member: "ayekan[01-03]"}
+cni::plugins::checksum: "f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37"
+cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "1.2.0"
+profile::core::rke::enable_dhcp: true
+profile::core::rke::version: "1.4.6-rc4"
+profile::core::common::manage_powertop: true
+profile::core::ospl::enable_rundir: true
+nm::connections:
+  eno1np0:
+    content: |
+      [connection]
+      id=eno1np0
+      uuid=f330f829-20cc-b829-67b0-18086a5fe6fa
+      type=ethernet
+      autoconnect=false
+      interface-name=eno1np0
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  eno2np1:
+    content: |
+      [connection]
+      id=eno2np1
+      uuid=de9904c8-9577-1a17-36b1-34b94132f06a
+      type=ethernet
+      autoconnect=false
+      interface-name=eno2np1
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  enp4s0f3u2u2c2:
+    content: |
+      [connection]
+      id=enp4s0f3u2u2c2
+      uuid=283f3035-13d7-4c87-9d7a-7d47861fa1f9
+      type=ethernet
+      autoconnect=false
+      interface-name=enp4s0f3u2u2c2
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  enp129s0f0:
+    content: |
+      [connection]
+      id=enp129s0f0
+      uuid=688bf5bf-d649-34b4-15eb-b07c50ac43f8
+      type=ethernet
+      interface-name=enp129s0f0
+
+      [ethernet]
+
+      [ipv4]
+      method=auto
+
+      [ipv6]
+      method=disabled
+  enp129s0f1:
+    content: |
+      [connection]
+      id=enp129s0f1
+      uuid=46d19ce1-bcab-7e77-6fc7-b730b26c54b1
+      type=ethernet
+      autoconnect=false
+      interface-name=enp129s0f1
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled

--- a/hieradata/cluster/ayekan/role/rke.yaml
+++ b/hieradata/cluster/ayekan/role/rke.yaml
@@ -1,0 +1,4 @@
+---
+classes:
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ayekan01.ls.lsst.org', :sitepp do
+  on_supported_os.each do |os, facts|
+    next if os =~ %r{centos-7-x86_64}
+
+    context "on #{os}" do
+      let(:facts) { override_facts(facts, fqdn: 'ayekan01.ls.lsst.org') }
+      let(:node_params) do
+        {
+          role: 'rke',
+          site: 'ls',
+          cluster: 'ayekan',
+        }
+      end
+
+      include_context 'with nm interface'
+
+      it { is_expected.to compile.with_all_deps }
+
+      it do
+        is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
+      end
+
+      it do
+        is_expected.to contain_class('clustershell').with(
+          groupmembers: {
+            'ayekan' => {
+              'group' => 'ayekan',
+              'member' => 'ayekan[01-03]',
+            },
+          },
+        )
+      end
+
+      it do
+        is_expected.to contain_class('profile::core::rke').with(
+          enable_dhcp: true,
+          version: '1.4.6-rc4',
+        )
+      end
+
+      it do
+        is_expected.to contain_class('cni::plugins').with(
+          version: '1.2.0',
+          checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
+          enable: ['macvlan'],
+        )
+      end
+
+      it { is_expected.to have_network__interface_resource_count(0) }
+      it { is_expected.to have_nm__connection_resource_count(5) }
+
+      %w[
+        eno1np0
+        eno2np1
+        enp4s0f3u2u2c2
+        enp129s0f1
+      ].each do |i|
+        context "with #{i}" do
+          let(:interface) { i }
+
+          it_behaves_like 'nm disabled interface'
+        end
+      end
+
+      context 'with enp129s0f0' do
+        let(:interface) { 'enp129s0f0' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm dhcp interface'
+        it_behaves_like 'nm ethernet interface'
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
This is basic initial configuration and test for the Observability cluster.
no tagging on VLANs for the secondary interface for now, will add if needed.