### PR TITLE
(profile::core::x2go) add support for EL9

### DIFF
--- a/hieradata/common/osfamily/RedHat/major/9.yaml
+++ b/hieradata/common/osfamily/RedHat/major/9.yaml
@@ -6,3 +6,8 @@ profile::core::yum::versionlock:
     release: "1.el9"
     before: "Package[puppet-agent]"
 profile::core::common::deploy_icinga_agent: false
+yum::managed_repos:
+  - "crb"
+yum::repos:
+  crb:  # provides deps for x2goserver
+    enabled: true

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -56,6 +56,13 @@ profile::ccs::common::packages:
   - "tcl"
   - "tcl-devel"
   - "time"
+profile::core::x2go::packages:
+  - "x2goagent"
+  - "x2goclient"
+  - "x2godesktopsharing"
+  - "x2goserver"
+  - "x2goserver-common"
+  - "x2goserver-xsession"
 profile::ts::nexusctio::repos:
   "nexus-ctio":
     ensure: "present"

--- a/site/profile/data/osfamily/RedHat/major/9.yaml
+++ b/site/profile/data/osfamily/RedHat/major/9.yaml
@@ -2,6 +2,12 @@
 profile::core::bash_completion::packages:
   - "bash-completion"
 
+profile::core::x2go::packages:
+  - "x2goagent"
+  - "x2goclient"
+  - "x2goserver"
+  - "x2goserver-common"
+  - "x2goserver-xsession"
 profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall

--- a/site/profile/manifests/core/x2go.pp
+++ b/site/profile/manifests/core/x2go.pp
@@ -1,14 +1,15 @@
 # @summary
 #   Adds additional packages for x2go agent
-class profile::core::x2go {
-  ensure_packages([
-      'x2goagent',
-      'x2goclient',
-      'x2godesktopsharing',
-      'x2goserver',
-      'x2goserver-common',
-      'x2goserver-xsession',
-  ])
+#
+# @param packages
+#  An array of packages to install
+#
+class profile::core::x2go (
+  Optional[Array[String[1]]] $packages = undef,
+) {
+  if $packages {
+    ensure_packages($packages)
+  }
 
   # the rpm set mode for this file is 644, which upsets the visudo command
   file { '/etc/sudoers.d/x2goserver':

--- a/spec/classes/core/x2go_spec.rb
+++ b/spec/classes/core/x2go_spec.rb
@@ -24,6 +24,29 @@ describe 'profile::core::x2go' do
           is_expected.to contain_file('/etc/sudoers.d/x2goserver')
             .that_comes_before('Sudo::Conf[bogus]')
         end
+
+        packages = if (facts[:os]['family'] == 'RedHat') && (facts[:os]['release']['major'] == '9')
+                     %w[
+                       x2goagent
+                       x2goclient
+                       x2godesktopsharing
+                       x2goserver
+                       x2goserver-common
+                       x2goserver-xsession
+                     ]
+                   else
+                     %w[
+                       x2goagent
+                       x2goclient
+                       x2goserver
+                       x2goserver-common
+                       x2goserver-xsession
+                     ]
+                   end
+
+        packages.each do |pkg|
+          it { is_expected.to contain_package(pkg) }
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -288,6 +288,11 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true, network: true
       network and it { is_expected.not_to contain_class('network') }
       it { is_expected.to contain_class('nm') }
       it { is_expected.to contain_package('NetworkManager-initscripts-updown') }
+      it { is_expected.to contain_class('yum').with_managed_repos(['crb']) }
+
+      it do
+        expect(catalogue.resource('class', 'yum')[:repos]['crb']).to include('enabled' => true)
+      end
     end
   else # not osfamily RedHat
     it { is_expected.not_to contain_class('epel') }


### PR DESCRIPTION
This is needed for the various ccs related roles on EL9.