### PR TITLE
(site/cp/role/foreman) change vlan1101 dhcp pool to 139.229.160.115-126

### DIFF
--- a/hieradata/site/cp/role/foreman.yaml
+++ b/hieradata/site/cp/role/foreman.yaml
@@ -16,7 +16,7 @@ dhcp::pools:
     mask: "255.255.255.0"
     gateway: "139.229.160.254"
     range:
-      - "139.229.160.1 139.229.160.99"
+      - "139.229.160.115 139.229.160.126"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   IT-GS:
     network: "139.229.161.0"

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -486,7 +486,7 @@ describe "#{role} role" do
           is_expected.to contain_dhcp__pool('IT-GSS').with(
             network: '139.229.160.0',
             mask: '255.255.255.0',
-            range: ['139.229.160.1 139.229.160.99'],
+            range: ['139.229.160.115 139.229.160.126'],
             gateway: '139.229.160.254',
           )
         end


### PR DESCRIPTION
The previous pool range overlapped with a large number of dhcp reservations for servers.