### PR TITLE
(role/nfsserver.cp) add nfs2 to jhome client list

### DIFF
--- a/hieradata/site/cp/role/nfsserver.yaml
+++ b/hieradata/site/cp/role/nfsserver.yaml
@@ -36,6 +36,7 @@ nfs::nfs_exports_global:
       %{facts.networking.ip}/32(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
+      nfs2.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
   /data/lsstdata:
     clients: >-
       139.229.146.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)

--- a/spec/hosts/roles/nfsserver_spec.rb
+++ b/spec/hosts/roles/nfsserver_spec.rb
@@ -34,16 +34,69 @@ describe "#{role} role" do
 
         it do
           expect(catalogue.resource('class', 'nfs')[:nfs_v4_export_root_clients]).to include(
+            '139.229.146.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.160.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.163.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.164.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.165.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.169.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.175.0/26(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.175.128/25(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
             'azar03.cp.lsst.org(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
+            '139.229.191.0/25(rw,fsid=root,insecure,no_subtree_check,async,root_squash)',
           )
         end
 
         it { is_expected.to contain_class('nfs::server').with_nfs_v4(true) }
+
+        it do
+          expect(catalogue.resource('nfs::server::export', '/data/home')[:clients])
+            .to include(
+              '139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.128/25(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+            )
+        end
+
+        it do
+          expect(catalogue.resource('nfs::server::export', '/data/jhome')[:clients])
+            .to include(
+              '139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+              'nfs2.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+            )
+        end
+
+        it do
+          expect(catalogue.resource('nfs::server::export', '/data/lsstdata')[:clients])
+            .to include(
+              '139.229.146.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.165.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.0/26(ro,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.128/25(ro,nohide,insecure,no_subtree_check,async,root_squash)',
+              'ts-csc-generic-01.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              'comcam-archiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+            )
+        end
+
         it { is_expected.to contain_nfs__server__export('/data/project') }
 
         it do
           expect(catalogue.resource('nfs::server::export', '/data/project')[:clients])
             .to include(
+              '139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.169.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.128/25(rw,nohide,insecure,no_subtree_check,async,root_squash)',
               'azar03.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)',
             )
         end
@@ -53,7 +106,25 @@ describe "#{role} role" do
         it do
           expect(catalogue.resource('nfs::server::export', '/data/scratch')[:clients])
             .to include(
+              '139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.0/26(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.175.128/25(rw,nohide,insecure,no_subtree_check,async,root_squash)',
               'azar03.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+            )
+        end
+
+        it do
+          expect(catalogue.resource('nfs::server::export', '/data/dimm')[:clients])
+            .to include(
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.163.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.164.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.191.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)',
             )
         end
 


### PR DESCRIPTION
In order to make nfs1 backups more easy, we added access network to the jhome mount on the 139.229.165/24 network. 