### PR TITLE
(foreman.cp) Fix range on LHN summit network

### DIFF
--- a/hieradata/site/cp/role/foreman.yaml
+++ b/hieradata/site/cp/role/foreman.yaml
@@ -151,7 +151,7 @@ dhcp::pools:
     mask: "255.255.255.0"
     gateway: "139.229.180.254"
     range:
-      - "139.229.180.1 139.229.180.62"  # ~/26
+      - "139.229.180.71 139.229.180.100"  # ~/27
     search_domains: "%{alias('dhcp::dnsdomain')}"
     static_routes:
       - {network: "134.79.20", mask: "23", gateway: "139.229.180.254"}

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -655,7 +655,7 @@ describe "#{role} role" do
           is_expected.to contain_dhcp__pool('yagan-lhn').with(
             network: '139.229.180.0',
             mask: '255.255.255.0',
-            range: ['139.229.180.1 139.229.180.62'],
+            range: ['139.229.180.71 139.229.180.100'],
             gateway: '139.229.180.254',
             static_routes: [
               { 'network' => '134.79.20', 'mask' => '23', 'gateway' => '139.229.180.254' },


### PR DESCRIPTION
The foreman DHCP was having IP conflicts with the MetalLB Pool on Yagan... so in order to avoid this issue, we moved the range on the foreman DHCP over the range of IPs reserved for MetalLB. (yagan and chonchon use LHN)