### PR TITLE
(ccs) update ts_sal_utils for cycle 32

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -129,7 +129,7 @@ ccs_software::udp_properties:
 
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
+  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"
 
 daq::daqsdk::purge: false
 daq::daqsdk::version: "R5-V6.7"

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -42,7 +42,7 @@ ccs_database::database: "comcamdbprod"
 
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
+  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"
 
 ## Used in lookups:
 ccs_site: "summit"

--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -25,7 +25,7 @@ ccs_database::database: "ccsdbprod"
 
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.3.0-1.x86_64.rpm"
+  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"
 ccs_sal::rpms_private:
   OpenSpliceDDS: "OpenSpliceDDS-6.10.4-6.el7.x86_64.rpm"
 

--- a/hieradata/site/cp/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/cp/cluster/auxtel-ccs.yaml
@@ -1,3 +1,0 @@
----
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"

--- a/hieradata/site/cp/cluster/comcam-ccs.yaml
+++ b/hieradata/site/cp/cluster/comcam-ccs.yaml
@@ -1,3 +1,0 @@
----
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"

--- a/hieradata/site/tu/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/tu/cluster/auxtel-ccs.yaml
@@ -2,9 +2,6 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "auxtel-mcm-dds.tu.lsst.org"
 
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"
-
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 
 ccs_monit::alert:

--- a/hieradata/site/tu/cluster/comcam-ccs.yaml
+++ b/hieradata/site/tu/cluster/comcam-ccs.yaml
@@ -2,9 +2,6 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "comcam-mcm-dds.tu.lsst.org"
 
-ccs_sal::rpms:
-  ts_sal_utils: "ts_sal_utils-7.4.0-1.x86_64.rpm"
-
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 
 ccs_monit::alert:


### PR DESCRIPTION
This makes ts_sal_utils 7.4.0-1 the default on all active ccs clusters. Remove now superfluous site-specific settings.