### PR TITLE
(site/cp/role/foremean) change vlan1511 dhcp pool to 139.229.175.101-120

### DIFF
--- a/hieradata/site/cp/role/foreman.yaml
+++ b/hieradata/site/cp/role/foreman.yaml
@@ -128,7 +128,7 @@ dhcp::pools:
     mask: "255.255.255.192"
     gateway: "139.229.175.126"
     range:
-      - "139.229.175.65 139.229.175.125"
+      - "139.229.175.101 139.229.175.120"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   CCS-Test-APP:
     network: "139.229.175.128"

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -628,7 +628,7 @@ describe "#{role} role" do
           is_expected.to contain_dhcp__pool('CCS-LSSTCam').with(
             network: '139.229.175.64',
             mask: '255.255.255.192',
-            range: ['139.229.175.65 139.229.175.125'],
+            range: ['139.229.175.101 139.229.175.120'],
             gateway: '139.229.175.126',
           )
         end


### PR DESCRIPTION
The current dhcp pool includes the entire usable range of the subnet and overlaps with dhcp reservations and addresses assigned to network switches.