### PR TITLE
(ccs) allow installation of required jdk8 on el9

### DIFF
--- a/site/profile/manifests/ccs/common.pp
+++ b/site/profile/manifests/ccs/common.pp
@@ -31,6 +31,10 @@ class profile::ccs::common (
     include profile::daq::sysctl
   }
 
+  if fact('os.release.major') == '9' {
+    include profile::ccs::el9
+  }
+
   include ccs_software
   include java_artisanal
   include java_artisanal::java17

--- a/site/profile/manifests/ccs/el9.pp
+++ b/site/profile/manifests/ccs/el9.pp
@@ -1,0 +1,40 @@
+# @summary
+#   EL9-specific requirements.
+#
+# @param rpms
+#   Hash of package/rpm pairs to install.
+# @param pkgurl
+#   String specifying url to fetch binaries from
+# @param pkgurl_user
+#   String specifying username for pkgurl
+# @param pkgurl_pass
+#   String specifying password for pkgurl
+#
+class profile::ccs::el9 (
+  Hash[String,String] $rpms = {
+    'compat-bin' => 'compat-bin-1.0.0-1.el9.noarch.rpm',
+  },
+  String $pkgurl = $profile::ccs::common::pkgurl,
+  String $pkgurl_user = $profile::ccs::common::pkgurl_user,
+  String $pkgurl_pass = $profile::ccs::common::pkgurl_pass,
+) {
+  $rpm_opts = {
+    ensure   => 'latest',
+    provider => 'rpm',
+  }
+
+  $rpms.each |$package, $rpm| {
+    $file = "/var/tmp/${rpm}"
+
+    archive { $file:
+      ensure   => present,
+      source   => "${pkgurl}/${rpm}",
+      username => $pkgurl_user,
+      password => $pkgurl_pass,
+    }
+    package { $package:
+      source => $file,
+      *      => $rpm_opts,
+    }
+  }
+}

--- a/spec/classes/ccs/el9_spec.rb
+++ b/spec/classes/ccs/el9_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::ccs::el9' do
+  on_supported_os.each do |os, facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end # on os
+  end  # on_supported_os
+end

--- a/spec/classes/ccs/el9_spec.rb
+++ b/spec/classes/ccs/el9_spec.rb
@@ -10,6 +10,8 @@ describe 'profile::ccs::el9' do
       let(:facts) { facts }
 
       it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_package('compat-bin') }
     end # on os
   end  # on_supported_os
 end


### PR DESCRIPTION
The jdk8 rpm required by CCS does not install out of the box on EL9 due to the merging of /bin and /usr/bin making it think some dependencies are not present (when they are). Install a trivial compat rpm to provide the "missing" dependencies and allow jdk8 to install.