### PR TITLE
(role/ipareplica) update ipa[12].dev tailscale addresses

### DIFF
--- a/hieradata/role/ipareplica.yaml
+++ b/hieradata/role/ipareplica.yaml
@@ -52,9 +52,9 @@ tailscale::up_options:
 
 hosts::host_entries:
   ipa1.dev.lsst.org:
-    ip: "100.85.248.128"
+    ip: "100.112.180.100"
   ipa2.dev.lsst.org:
-    ip: "100.124.223.22"
+    ip: "100.71.133.15"
   ipa1.tu.lsst.org:
     ip: "100.107.132.55"
   ipa2.tu.lsst.org:

--- a/spec/hosts/roles/ipareplica_spec.rb
+++ b/spec/hosts/roles/ipareplica_spec.rb
@@ -70,8 +70,8 @@ describe "#{role} role" do
           end
 
           {
-            'ipa1.dev.lsst.org': '100.85.248.128',
-            'ipa2.dev.lsst.org': '100.124.223.22',
+            'ipa1.dev.lsst.org': '100.112.180.100',
+            'ipa2.dev.lsst.org': '100.71.133.15',
             'ipa1.tu.lsst.org': '100.107.132.55',
             'ipa2.tu.lsst.org': '100.127.11.142',
             'ipa3.tu.lsst.org': '100.87.197.47',


### PR DESCRIPTION
The tailscale IP addresses changed when reprovisoining the hosts.