### PR TITLE
(node/core[123].tu.lsst.org) migrate to EL9

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -56,6 +56,9 @@ lookup_options:
   ssh::server::match_block:
     merge:
       strategy: "deep"
+  profile::core::ipa::default:
+    merge:
+      strategy: "deep"
   profile::core::systemd::tmpfile:
     merge:
       strategy: "deep"

--- a/hieradata/node/core1.tu.lsst.org.yaml
+++ b/hieradata/node/core1.tu.lsst.org.yaml
@@ -5,6 +5,22 @@ ipmi::networks:
     netmask: "255.255.255.192"
     gateway: "140.252.146.129"
     type: "static"
-network::interfaces_hash:
+nm::connections:
   em1:  # fqdn
-    ipaddress: "140.252.146.68"
+    content: |
+      [connection]
+      id=em1
+      uuid=19429662-4ca9-3632-932f-56e3d300bd9a
+      type=ethernet
+      interface-name=em1
+
+      [ethernet]
+
+      [ipv4]
+      address1=140.252.146.68/27,140.252.146.65
+      dns=140.252.146.71;140.252.146.72;140.252.146.73
+      dns-search=tu.lsst.org;
+      method=manual
+
+      [ipv6]
+      method=disabled

--- a/hieradata/node/core2.tu.lsst.org.yaml
+++ b/hieradata/node/core2.tu.lsst.org.yaml
@@ -5,6 +5,22 @@ ipmi::networks:
     netmask: "255.255.255.192"
     gateway: "140.252.146.129"
     type: "static"
-network::interfaces_hash:
+nm::connections:
   em1:  # fqdn
-    ipaddress: "140.252.146.69"
+    content: |
+      [connection]
+      id=em1
+      uuid=19429662-4ca9-3632-932f-56e3d300bd9a
+      type=ethernet
+      interface-name=em1
+
+      [ethernet]
+
+      [ipv4]
+      address1=140.252.146.69/27,140.252.146.65
+      dns=140.252.146.71;140.252.146.72;140.252.146.73
+      dns-search=tu.lsst.org;
+      method=manual
+
+      [ipv6]
+      method=disabled

--- a/hieradata/node/core3.tu.lsst.org.yaml
+++ b/hieradata/node/core3.tu.lsst.org.yaml
@@ -5,6 +5,22 @@ ipmi::networks:
     netmask: "255.255.255.192"
     gateway: "140.252.146.129"
     type: "static"
-network::interfaces_hash:
+nm::connections:
   em1:  # fqdn
-    ipaddress: "140.252.146.70"
+    content: |
+      [connection]
+      id=em1
+      uuid=19429662-4ca9-3632-932f-56e3d300bd9a
+      type=ethernet
+      interface-name=em1
+
+      [ethernet]
+
+      [ipv4]
+      address1=140.252.146.70/27,140.252.146.65
+      dns=140.252.146.71;140.252.146.72;140.252.146.73
+      dns-search=tu.lsst.org;
+      method=manual
+
+      [ipv6]
+      method=disabled

--- a/hieradata/node/ipa1.tu.lsst.org.yaml
+++ b/hieradata/node/ipa1.tu.lsst.org.yaml
@@ -1,4 +1,6 @@
 ---
+# need to use an off site ipa replica to bootstrap the first local ipa instance
+easy_ipa::ipa_master_fqdn: "ipa1.cp.lsst.org"
 network::interfaces_hash:
   eth0:  # fqdn
     ipaddress: "140.252.146.74"

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -215,6 +215,7 @@ profile::core::puppet_master::foreman_config:
   host_details_ui: {value: false}  # https://projects.theforeman.org/issues/35115
   host_power_status: {value: false}
   idle_timeout: {value: 7200}  # session timeout in minutes
+  ignore_puppet_facts_for_provisioning: {value: true}
   matchers_inheritance: {value: false}
   maximum_structured_facts: {value: 1000}
   update_hostgroup_from_facts: {value: false}

--- a/hieradata/role/ipareplica.yaml
+++ b/hieradata/role/ipareplica.yaml
@@ -36,6 +36,10 @@ clustershell::groupmembers:
       - "ipa1.dev.lsst.org"
 
 profile::core::ipa_pwd_reset::ldap_user: "ldap-passwd-reset"
+profile::core::ipa::default:
+  global:
+    server: "%{facts.fqdn}"
+    xmlrpc_uri: "https://%{facts.fqdn}/ipa/xml"
 
 tailscale::up_options:
   accept-dns: false  # leave /etc/resolv.conf alone

--- a/hieradata/role/ipareplica.yaml
+++ b/hieradata/role/ipareplica.yaml
@@ -40,6 +40,7 @@ profile::core::ipa::default:
   global:
     server: "%{facts.fqdn}"
     xmlrpc_uri: "https://%{facts.fqdn}/ipa/xml"
+openldap::client::uri: "ldaps://%{facts.fqdn}"
 
 tailscale::up_options:
   accept-dns: false  # leave /etc/resolv.conf alone

--- a/hieradata/site/tu/role/hypervisor.yaml
+++ b/hieradata/site/tu/role/hypervisor.yaml
@@ -49,3 +49,129 @@ network::interfaces_hash:
     type: "bridge"
   br3085:  # misc-dds
     <<: *bridge_int
+nm::connections:
+  em2:  # not connected
+    content: |
+      [connection]
+      id=em2
+      uuid=74c4ee68-1de0-4a6d-9237-4992c34d244f
+      type=ethernet
+      autoconnect=false
+      interface-name=em2
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  p2p1:  # trunk
+    content: |
+      [connection]
+      id=p2p1
+      uuid=c4374a59-af0a-42e0-aeeb-718c87273e51
+      type=ethernet
+      autoconnect=false
+      interface-name=p2p1
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+  p2p2:  # not connected
+    content: |
+      [connection]
+      id=p2p2
+      uuid=29b8c67a-2020-4f20-9647-fca2c48e1b2d
+      type=ethernet
+      autoconnect=false
+      interface-name=p2p2
+
+      [ethernet]
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+
+  p2p1.3040:
+    content: |
+      [connection]
+      id=p2p1.3040
+      uuid=83eb4bbb-5f05-4d9d-9c0e-d465309a8cd9
+      type=vlan
+      interface-name=p2p1.3040
+      master=br3040
+      slave-type=bridge
+
+      [ethernet]
+
+      [vlan]
+      flags=1
+      id=3040
+      parent=p2p1
+
+      [bridge-port]
+  p2p1.3085:
+    content: |
+      [connection]
+      id=p2p1.3085
+      uuid=c10f7f90-86c4-4244-ad6f-15898cbe729f
+      type=vlan
+      interface-name=p2p1.3085
+      master=br3085
+      slave-type=bridge
+
+      [ethernet]
+
+      [vlan]
+      flags=1
+      id=3085
+      parent=p2p1
+
+      [bridge-port]
+  br3040:
+    content: |
+      [connection]
+      id=br3040
+      uuid=d032d1d6-9080-493b-bd2c-e243f8e1ba35
+      type=bridge
+      interface-name=br3040
+
+      [ethernet]
+
+      [bridge]
+      stp=false
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+
+      [proxy]
+  br3085:
+    content: |
+      [connection]
+      id=br3085
+      uuid=a578f93b-06c2-0434-5437-a69b0542c27e
+      type=bridge
+      interface-name=br3085
+
+      [ethernet]
+
+      [bridge]
+      stp=false
+
+      [ipv4]
+      method=disabled
+
+      [ipv6]
+      method=disabled
+
+      [proxy]

--- a/hieradata/site/tu/role/hypervisor.yaml
+++ b/hieradata/site/tu/role/hypervisor.yaml
@@ -9,46 +9,6 @@ accounts::user_list:
     system: true
     sshkeys:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGCCYvVfrd3RvPlGtXh+e3NWWw7OVzvIyX9jj1jT2omYt07gPv2nx9xgHqtkr1n39aezN4T2/9PuuCinN/dCOAmDd1J3lV+4rbWVUQD1o356ElxnVgdDm7RLwFfGjNW+WnVVOSXudZaO8wN6JqzG0SM21bmaIrT5b8pmXI9aafIEtnVhUKpVrqXOMQR8RNF9nvnzQulRkX7y/Kcy//a1v6/1lt4D+0Y5QaQujt04i8+QkcUBNe9sukjYWfzcPW9FpdJAiiydxwJl27f8OvJ4OMp1LJkB8lI5BLvJQpJ6u0DlfjkrSusDx60MSU3LQKP9TsaOW16b+/FqcHpkSpLGy/ foreman@foreman.tuc.lsst.cloud"
-network::interfaces_hash:
-  em1:  # fqdn
-    bootproto: "none"
-    defroute: "yes"
-    dns1: "%{lookup('dhcp::nameservers.0')}"
-    dns2: "%{lookup('dhcp::nameservers.1')}"
-    domain: "%{lookup('dhcp::dnsdomain.0')}"
-    gateway: "140.252.146.65"
-    netmask: "255.255.255.224"
-    nozeroconf: "yes"
-    onboot: "yes"
-    type: "Ethernet"
-  em2:  # not connected
-    bootproto: "none"
-    onboot: "no"
-    type: "Ethernet"
-  p2p1:  # hypervisor
-    bootproto: "none"
-    onboot: "yes"
-    type: "Ethernet"
-  p2p2:  # not connected
-    bootproto: "none"
-    onboot: "no"
-    type: "Ethernet"
-  p2p1.3040: &vlan_int
-    bootproto: "none"
-    bridge: "br3040"
-    nozeroconf: "yes"
-    onboot: "yes"
-    type: "none"
-    vlan: "yes"
-  p2p1.3085:
-    <<: *vlan_int
-    bridge: "br3085"
-  br3040: &bridge_int  # coresvc
-    bootproto: "none"
-    onboot: "yes"
-    type: "bridge"
-  br3085:  # misc-dds
-    <<: *bridge_int
 nm::connections:
   em2:  # not connected
     content: |

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 profile::core::convenience::packages:
   - "ack"
+  - "diffstat"
   - "fpart"
   - "git"
   - "jq"

--- a/spec/hosts/nodes/core2.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/core2.tu.lsst.org_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 describe 'core2.tu.lsst.org', :sitepp do
-  on_supported_os.each do |os, facts|
-    # XXX networking needs to be updated to support EL8+
-    next unless os =~ %r{centos-7-x86_64}
-
+  alma9 = FacterDB.get_facts({ operatingsystem: 'AlmaLinux', operatingsystemmajrelease: '9' }).first
+  # rubocop:disable Naming/VariableNumber
+  { 'almalinux-9-x86_64': alma9 }.each do |os, facts|
+    # rubocop:enable Naming/VariableNumber
     context "on #{os}" do
       let(:facts) do
         override_facts(facts,
@@ -37,12 +37,64 @@ describe 'core2.tu.lsst.org', :sitepp do
                            type: 'static',
                          },
                        })
+      include_context 'with nm interface'
 
-      it do
-        is_expected.to contain_network__interface('em1').with(
-          ipaddress: '140.252.146.69',
-        )
+      it { is_expected.to have_nm__connection_resource_count(8) }
+
+      %w[
+        em2
+        p2p1
+        p2p2
+      ].each do |i|
+        context "with #{i}" do
+          let(:interface) { i }
+
+          it_behaves_like 'nm disabled interface'
+        end
+      end
+
+      context 'with em1' do
+        let(:interface) { 'em1' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('140.252.146.69/27,140.252.146.65') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('140.252.146.71;140.252.146.72;140.252.146.73') }
+        it { expect(nm_keyfile['ipv4']['dns-search']).to eq('tu.lsst.org;') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
+      end
+
+      context 'with p2p1.3040' do
+        let(:interface) { 'p2p1.3040' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm vlan interface', id: 3040, parent: 'p2p1'
+        it_behaves_like 'nm bridge slave interface', master: 'br3040'
+      end
+
+      context 'with p2p1.3085' do
+        let(:interface) { 'p2p1.3085' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm vlan interface', id: 3085, parent: 'p2p1'
+        it_behaves_like 'nm bridge slave interface', master: 'br3085'
+      end
+
+      context 'with br3040' do
+        let(:interface) { 'br3040' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm no-ip interface'
+        it_behaves_like 'nm bridge interface'
+      end
+
+      context 'with br3085' do
+        let(:interface) { 'br3085' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm no-ip interface'
+        it_behaves_like 'nm bridge interface'
       end
     end # on os
   end # on_supported_os
-end # role
+end

--- a/spec/hosts/nodes/core3.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/core3.tu.lsst.org_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 describe 'core3.tu.lsst.org', :sitepp do
-  on_supported_os.each do |os, facts|
-    # XXX networking needs to be updated to support EL8+
-    next unless os =~ %r{centos-7-x86_64}
-
+  alma9 = FacterDB.get_facts({ operatingsystem: 'AlmaLinux', operatingsystemmajrelease: '9' }).first
+  # rubocop:disable Naming/VariableNumber
+  { 'almalinux-9-x86_64': alma9 }.each do |os, facts|
+    # rubocop:enable Naming/VariableNumber
     context "on #{os}" do
       let(:facts) do
         override_facts(facts,
@@ -37,12 +37,64 @@ describe 'core3.tu.lsst.org', :sitepp do
                            type: 'static',
                          },
                        })
+      include_context 'with nm interface'
 
-      it do
-        is_expected.to contain_network__interface('em1').with(
-          ipaddress: '140.252.146.70',
-        )
+      it { is_expected.to have_nm__connection_resource_count(8) }
+
+      %w[
+        em2
+        p2p1
+        p2p2
+      ].each do |i|
+        context "with #{i}" do
+          let(:interface) { i }
+
+          it_behaves_like 'nm disabled interface'
+        end
+      end
+
+      context 'with em1' do
+        let(:interface) { 'em1' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('140.252.146.70/27,140.252.146.65') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('140.252.146.71;140.252.146.72;140.252.146.73') }
+        it { expect(nm_keyfile['ipv4']['dns-search']).to eq('tu.lsst.org;') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
+      end
+
+      context 'with p2p1.3040' do
+        let(:interface) { 'p2p1.3040' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm vlan interface', id: 3040, parent: 'p2p1'
+        it_behaves_like 'nm bridge slave interface', master: 'br3040'
+      end
+
+      context 'with p2p1.3085' do
+        let(:interface) { 'p2p1.3085' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm vlan interface', id: 3085, parent: 'p2p1'
+        it_behaves_like 'nm bridge slave interface', master: 'br3085'
+      end
+
+      context 'with br3040' do
+        let(:interface) { 'br3040' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm no-ip interface'
+        it_behaves_like 'nm bridge interface'
+      end
+
+      context 'with br3085' do
+        let(:interface) { 'br3085' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm no-ip interface'
+        it_behaves_like 'nm bridge interface'
       end
     end # on os
   end # on_supported_os
-end # role
+end

--- a/spec/hosts/roles/ipareplica_spec.rb
+++ b/spec/hosts/roles/ipareplica_spec.rb
@@ -54,6 +54,18 @@ describe "#{role} role" do
             end
           end
 
+          it do
+            is_expected.to contain_ini_setting('/etc/ipa/default.conf [global] host').with_value(facts[:fqdn])
+          end
+
+          it do
+            is_expected.to contain_ini_setting('/etc/ipa/default.conf [global] server').with_value(facts[:fqdn])
+          end
+
+          it do
+            is_expected.to contain_ini_setting('/etc/ipa/default.conf [global] xmlrpc_uri').with_value("https://#{facts[:fqdn]}/ipa/xml")
+          end
+
           case os
           when 'centos-7-x86_64'
             %w[

--- a/spec/hosts/roles/ipareplica_spec.rb
+++ b/spec/hosts/roles/ipareplica_spec.rb
@@ -66,6 +66,10 @@ describe "#{role} role" do
             is_expected.to contain_ini_setting('/etc/ipa/default.conf [global] xmlrpc_uri').with_value("https://#{facts[:fqdn]}/ipa/xml")
           end
 
+          it do
+            is_expected.to contain_class('openldap::client').with_uri("ldaps://#{facts[:fqdn]}")
+          end
+
           case os
           when 'centos-7-x86_64'
             %w[

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -810,6 +810,7 @@ shared_examples 'generic foreman' do
     bmc_credentials_accessible: false,
     default_pxe_item_global: 'discovery',
     host_details_ui: false,
+    ignore_puppet_facts_for_provisioning: true,
     template_sync_associate: 'always',
     template_sync_commit_msg: 'Templates export made by a Foreman user',
     template_sync_dirname: '/',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -897,6 +897,7 @@ end
 shared_examples 'convenience' do
   %w[
     ack
+    diffstat
     fpart
     git
     jq


### PR DESCRIPTION
+ rebuild ipa[13].tu.lsst.org due to replication problems discovered after the EL9 migration of the core hypervisors.