### PR TITLE
(node/hexrot) profile for hexrot

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,6 +12,7 @@ mod 'example42/network', git: 'https://github.com/lsst-it/puppet-network', ref: 
 mod 'jamtur01/httpauth', '0.0.6'
 mod 'jcpunk/irqbalance', '1.0.5'
 mod 'jhoblitt/ipmi', '5.3.1'
+mod 'lsst/anaconda', '0.1.0'
 mod 'lsst/ccs_daq', '1.1.0'
 mod 'lsst/ccs_database', '3.3.0'
 mod 'lsst/ccs_hcu', '3.5.0'

--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "anaconda"
   - "mate"
   - "profile::core::common"
   - "profile::core::debugutils"
@@ -7,6 +8,7 @@ classes:
   - "profile::core::docker::prune"
   - "profile::core::ni_packages"
   - "profile::core::x2go"
+  - "profile::ts::hexrot"
   - "profile::ts::nexusctio"
 files:
   /rubin:
@@ -18,6 +20,8 @@ files:
     subscribe:
       - "Package[runHexEui]"
       - "Package[runRotEui]"
+      - "Package[runM2Cntlr]"
+
 # / on hexrot.cp was formated with xfs fstype=0 (long, long, long ago) and is
 # not compatible with overlayfs[2]
 profile::core::docker::storage_driver: "devicemapper"
@@ -27,3 +31,23 @@ accounts::group_list:
     ensure: "present"
     gid: 70014
     forcelocal: true
+
+anaconda::anaconda_version: "Anaconda3-2023.07-2"
+anaconda::python_env_name: "py311"
+anaconda::python_env_version: "3.11"
+anaconda::conda_packages:
+  pyside6:
+    channel: "conda-forge"
+    version: "6.7.0"
+  qasync:
+    channel: "conda-forge"
+    version: "0.23.0"
+  qt6-charts:
+    channel: "conda-forge"
+    version: "6.7.0"
+  ts-m2com:
+    channel: "lsstts"
+    version: "1.5.4"
+  ts-m2gui:
+    channel: "lsstts"
+    version: "1.0.2"

--- a/site/profile/manifests/ts/hexrot.pp
+++ b/site/profile/manifests/ts/hexrot.pp
@@ -1,0 +1,45 @@
+# @summary
+# Sets up repos and symlinks for hexrot
+
+class profile::ts::hexrot {
+  vcsrepo { '/opt/ts_config_mttcs':
+    ensure             => present,
+    provider           => git,
+    source             => 'https://github.com/lsst-ts/ts_config_mttcs.git',
+    revision           => 'v0.12.8',
+    keep_local_changes => false,
+  }
+  file { '/etc/profile.d/hexrot_path.sh':
+    ensure  => file,
+    mode    => '0644',
+    # lint:ignore:strict_indent
+    content => @(ENV),
+        export QT_API="PySide6"
+        export PYTEST_QT_API="PySide6"
+        export TS_CONFIG_MTTCS_DIR="/opt/ts_config_mttcs"
+        | ENV
+    # lint:endignore
+    require => Vcsrepo['/opt/ts_config_mttcs'],
+  }
+  file { '/rubin/mtm2/python':
+    ensure => directory,
+    owner  => 73006,
+    group  => 73006,
+  }
+  file { '/rubin/mtm2/python/run_m2gui':
+    ensure => link,
+    owner  => 73006,
+    group  => 73006,
+    target => '/opt/anaconda/envs/py311/bin/run_m2gui',
+  }
+  file { ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2']:
+    ensure  => directory,
+    owner   => 73006,
+    group   => 73006,
+    recurse => true,
+  }
+  file { ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log']:
+    ensure => directory,
+    mode   => '0775',
+  }
+}

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -6,6 +6,8 @@ role = 'hexrot'
 
 describe "#{role} role" do
   on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:node_params) do
@@ -24,24 +26,117 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
+          include_examples 'debugutils'
           include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
+          include_examples 'ni_packages'
+          include_examples 'nexusctio'
           it { is_expected.to contain_class('mate') }
 
           # XXX hexrot uses devicemapper, so the docker example group isn't included
-          it { is_expected.to contain_class('docker') }
+          it do
+            is_expected.to contain_class('docker').with(
+              package_source: 'docker-ce',
+              socket_group: 70_014,
+              socket_override: false,
+              storage_driver: 'devicemapper',
+            )
+          end
 
-          %w[
-            profile::core::common
-            profile::core::debugutils
-            profile::core::docker
-            profile::core::docker::prune
-            profile::core::ni_packages
-          ].each do |c|
-            it { is_expected.to contain_class(c) }
+          it { is_expected.to contain_cron__job('docker_prune') }
+
+          it do
+            is_expected.to contain_vcsrepo('/opt/ts_config_mttcs').with(
+              ensure: 'present',
+              provider: 'git',
+              source: 'https://github.com/lsst-ts/ts_config_mttcs.git',
+              revision: 'v0.12.8',
+              keep_local_changes: 'false',
+            )
+          end
+
+          pkgs = {
+            'pyside6' => {
+              'channel' => 'conda-forge',
+              'version' => '6.7.0',
+            },
+            'qasync' => {
+              'channel' => 'conda-forge',
+              'version' => '0.23.0',
+            },
+            'qt6-charts' => {
+              'channel' => 'conda-forge',
+              'version' => '6.7.0',
+            },
+            'ts-m2com' => {
+              'channel' => 'lsstts',
+              'version' => '1.5.4',
+            },
+            'ts-m2gui' => {
+              'channel' => 'lsstts',
+              'version' => '1.0.2',
+            },
+          }
+
+          it do
+            is_expected.to contain_class('anaconda').with(
+              anaconda_version: 'Anaconda3-2023.07-2',
+              python_env_name: 'py311',
+              python_env_version: '3.11',
+              conda_packages: pkgs,
+            )
           end
 
           it { is_expected.to contain_package('docker-compose-plugin') }
+
+          it do
+            is_expected.to contain_file('/etc/profile.d/hexrot_path.sh').with(
+              ensure: 'file',
+              mode: '0644',
+              content: <<~CONTENT,
+              export QT_API="PySide6"
+              export PYTEST_QT_API="PySide6"
+              export TS_CONFIG_MTTCS_DIR="/opt/ts_config_mttcs"
+              CONTENT
+            )
+          end
+
+          it do
+            is_expected.to contain_file('/rubin/mtm2/python').with(
+              ensure: 'directory',
+              owner: '73006',
+              group: '73006',
+            )
+          end
+
+          it do
+            is_expected.to contain_file('/rubin/mtm2/python/run_m2gui').with(
+              ensure: 'link',
+              owner: '73006',
+              group: '73006',
+              target: '/opt/anaconda/envs/py311/bin/run_m2gui',
+            )
+          end
+
+          ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2'].each do |path|
+            it do
+              is_expected.to contain_file(path).with(
+                ensure: 'directory',
+                owner: '73006',
+                group: '73006',
+                recurse: 'true',
+              )
+            end
+          end
+
+          ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log'].each do |path|
+            it do
+              is_expected.to contain_file(path).with(
+                ensure: 'directory',
+                mode: '0775',
+              )
+            end
+          end
         end # host
       end # lsst_sites
     end # on os

--- a/spec/support/spec/nexusctio.rb
+++ b/spec/support/spec/nexusctio.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+shared_examples 'nexusctio' do
+  it do
+    is_expected.to contain_yumrepo('nexus-ctio').with(
+      'baseurl' => 'http://cagvm3.ctio.noao.edu/nexus/repository/labview-rpm/rubin/',
+      'gpgcheck' => false,
+    )
+  end
+
+  it do
+    is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-MSO').with(
+      ensure: 'file',
+      mode: '0644',
+      content: <<~GPG,
+          -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.0.22 (GNU/Linux)
+
+        mQINBGC3zR8BEACw7AKpnTXmhvjHU5hfdBfbbdOx8azUtW3Oogr6zUcAMd0meTfj
+        4msB71LePoMX6WskN9RckoIJvxlIjcVPlbCe7euBDLiQL1KhuQXWK5veYIlsBYMx
+        agL8CA/rHEk1yfvuk9pxS7CqziRQ4laxJPnYbrOaRZevYlumyusDfGQ17x3EbM1D
+        N3UYvnzhla0lq/YmGSLVNgmqMV8PJSzv+iQku5MbI4ahxSCnVedOvepXdcePQPwf
+        /IZc/4IwquKjTNXCs+WhlMbM7T/0M1WeYm7h52UwUOlWB2pgN1ryW+iSbLCu0rBd
+        XJtPw4iERbhKpZmkmZJ6vrpCA+E2OFW2LIFve0N5mAUY0JkliFE34kG+FY6ZtD7z
+        vlF4U0AxzAOvo4zoIJcxRHjt7u4UsOIpMbBvm+B1rtbX3ZGGiZecpFhe5GONrh++
+        jvT4kcpKjADY4rSq583iDZ/mWF+XUozyTmqbuHxFVTjAKCNvQE0WyL9+5g9zCH1a
+        7AtIOSrfVP5YBHfLMiPOXpep8Pf7CaNAbSQb5JxFABYSRsLM6v2+Y3zm61dSIfeU
+        ZTRIFAsWG0Db5VdtdznBZnZRa5Avs6AUN9KOiVWi/D1KofZeeHU6DSfW+4Wq8vr4
+        Ekm8YUfQuPP6Fvre5qvytBf17MGg0vKZ7Z/ipdhs2StxFnoO+3yK2BfoKwARAQAB
+        tF9HUEcgTVNPIChHUEcgTVNPIHNpZ25hdHVyZSBmb3Igc3RhYmxlIHJwbSBmaWxl
+        cyBpbiBOZXh1czMgcmVwb3NpdG9yeSkgPGRpZWdvLmdvbWV6QG5vaXJsYWIuZWR1
+        PokCOQQTAQIAIwUCYLfNHwIbAwcLCQgHAwIBBhUIAgkKCwQWAgMBAh4BAheAAAoJ
+        EM5tAOEzBhcslQgP/2uGa/PZwVSo9/PHvnr7sD6/QT4hM0/Z2ngCGo0xOTTLm89C
+        K0DxkU21L9m2/BUZPJp4krB5p5GOUjiRdpouiPElnULBaBB8eZIVQWK3ifenqVq6
+        FqxNqFDBKcKQ9ZVgvz88GYHLDSYTvv2QtTozCVhjcSWCPorYRuLbliOc4k7jqmjk
+        5xUlCLcaGyHYZNXcLwDztgioF4AXyL3NUq2wySLfukJ0VxZ4z5jBfx5u47jUzvOV
+        j/t/OHZTwL4UGziEXgTb0j8ZRt2QciA5Sh0oXGUIlqZhWY88TBeG9xKUcsxB6TpV
+        NUSLOFt7Vq1Gxi9Eg8TWHvHyRRG/pfWIQyJdX5dKcAzsZMmB3jsx5TypnbxwM5dQ
+        k+IRCCLQQeLgBupBRKlF4PLns7R/CzouFIo9J/pVcxsZS2r2+t/S2i1N6/ApuqGR
+        Zo1QcKP8LGklwzcM6WQUHNlFJMzudULxAPt3ZNgKtktxEzfF44u9jWediWCHZv8N
+        /QgfxfaHMt4cQG2FCfZbISeBibo2YpRzPxMmuuTrS9tUEQ9VLiy59keZtu9hzD8R
+        AQ1p+6x1aGwGUTi8F/zdEv7PdCfsAMtZep/BkW2nnVoTJ886kJO2psm59Xw8rnRw
+        sX7IJd/rq/hw9ZyYRL1uU6CzHmSPR1Jwd2GOxxRS+OjutDMOWVe539KZP+mouQIN
+        BGC3zR8BEADBDUUBkVHRc/39iZYKFrmYVNoKPHdcIwrxwv9jt+2siBRFEKBix7Ji
+        pX+mvS8nu0tKCY0pASZZs5bi7M1Vc6w6I4x3Loam0d3oRwgQUzov0Hsmu9Qe8l6o
+        EaUdZbZn/V/V6ca5y3PFJRUOKeAvJC8lA4etgc4Gu7G8uy8QbpsfMrwV7DwW0C7U
+        p+rPjqtFs8tHm+IGuNaLnlIjCA7svSe/fcNuowj1S3WpWIVIGTq72ceGYhRhOxZ7
+        gkeZRYfe6mz2c+BYoSCbjrBg9E46gWIGfI43WTWEOMfAO4rvJvrLxKiIM+/Z34JE
+        M81Gwatyvq1ZxJOxlD2RiM/Hn9ErbuB9Y7h9et4bi9VwkDcHasbtJwaH18M2DN/D
+        OkKnsI0Zl9jRlSeAxBJYXZOLQSZekeNl6VGcbNwz8iq6M/ahnRy3AXEWiA7GGxVR
+        Lq2xGj9Dszy9lMdQRW7vyNN3+HwV8AQ8W0UgVQKAARDpMjhkVA61NJEk66tsobQE
+        CcAmbcedQT9bhHQaQc7rqO6By9REghpNt9OfO+57RKJhtZcPKKPaMsFBMGRpFm5x
+        /HZEkc9PDMpVwn2w8O2dO6veBoWqPxDfdBtnWiPcOQiXvc9qBQwmaLIFfJYQ0Ixm
+        Bt3DXes1dIw1bZI3oMOcNXBCt4UzsKJ2qaznlpzc50sc6OR6seOrEwARAQABiQIf
+        BBgBAgAJBQJgt80fAhsMAAoJEM5tAOEzBhcs8CgP/iod3QiQCP8IaHxT7pNmJ95M
+        tFSzoWRNvC/oSyD4pjt7zSEVv00Ztr9TaDNVvkImgeJEi2SrGyU1D4vUovbhftny
+        /2mHLBnu/N9tBGwBwhrv3C7Rn3K2AsRVcEQ2MMzfyvSDzrSicfjAlgblCGB0seuN
+        jCeAZOfjE/V9ZC+m1JkpnAs7T9ohM/q7HuYjzQIXFJVFz7tmfPUcg8OAm5VxqfVV
+        57ub2L8VgFR7slja0VIPnEG38VieSRmx02Inc8fEAAw/ah+EZXEvKap4O2laGY4y
+        VZVguIMRVVHAOTu0iUTwPlfPNI/jjn2J8ULisIfbuTKd0Vn30kaahBFY4E/R3h9C
+        geZo96fkKa4JwN7hKtZZv8uzwUWuFGuDlU1tQ2VkNUgj8ksfaagXE0G/L27iKeZN
+        mGwfdNWtlEnjiolxK2xNmzwotDqnneRZLz8uoCG3fogcJi28YqtHddCQdRNLxScx
+        DfJsUyrAgCt9bXnnJtKi5Kv6gAtkP02Qz7Kez8gh0W6VYQcRYOxLnmISaWf3woGx
+        05/9YPDdeXVApp8JHlmgLKM1nm2a2A8JsIaZpLGhBcawo1xicnU2yMSTvpgouopT
+        GtqYBCi14V6IEZbVzYeIz1EkT12RP7CtnWYbJN/zyenK3LMowkPigythoAY8tRzL
+        eO+RKR5uzsEbWmMvQkTP
+        =vYiw
+        -----END PGP PUBLIC KEY BLOCK-----
+      GPG
+    )
+  end
+end

--- a/spec/support/spec/ni_packages.rb
+++ b/spec/support/spec/ni_packages.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+shared_examples 'ni_packages' do
+  all_packages = [
+    'runHexEui',
+    'runRotEui',
+    'runM2Cntlr',
+    'git',
+    'mlocate',
+    'wget',
+    'openssl-devel',
+    'make',
+    'gcc-c++',
+    'bzip2-devel',
+    'libffi-devel',
+    'libXinerama',
+    'mesa-libGL',
+    'libstdc++.i686',
+    'libXft',
+    'libXinerama.i686',
+    'mesa-libGL.i686',
+  ]
+
+  all_packages.each do |pkg|
+    it { is_expected.to contain_package(pkg) }
+  end
+
+  it { is_expected.to contain_host('cagvm3.ctio.noao.edu').with(ip: '139.229.3.76') }
+end


### PR DESCRIPTION
This is a request on IT-4666 to:

- install anaconda and setup virtual environment with Python 3.11 (default for all users)
- install python packages on that environment to run ts_m2gui package
- download ts_config_mttcs repo on /opt/ts_config_mttcs
- change ownership and permissions to the /rubin/ folder (recursive) to the saluser
- create a softlink to /rubin/mtm2/python/run_m2gui
- set a couple of environment Variables to work with