### PR TITLE
(role/hypervisor) fix libvirt startup on EL9

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,7 @@ mod 'blockops/tailscale', git: 'https://github.com/lsst-it/puppet-tailscale', re
 mod 'camptocamp/augeas', '1.9.0'
 mod 'ccin2p3/etc_services', git: 'https://github.com/lsst-it/puppet-etc_services', ref: 'ff17b73' # https://github.com/ccin2p3/puppet-etc_services/pull/11
 mod 'ccin2p3/mit_krb5', git: 'https://github.com/lsst-it/puppet-mit_krb5.git', ref: 'f8f0242'  # https://github.com/ccin2p3/puppet-mit_krb5/pull/29 https://github.com/ccin2p3/puppet-mit_krb5/pull/34 https://github.com/ccin2p3/puppet-mit_krb5/pull/35
-mod 'cirrax/libvirt', '5.0.1'
+mod 'cirrax/libvirt', '5.0.2'
 mod 'derdanne/nfs', git: 'https://github.com/lsst-it/puppet-nfs', ref: '6d51f51'  # https://github.com/derdanne/puppet-nfs/pull/170
 mod 'duritong/sysctl', git: 'https://github.com/duritong/puppet-sysctl', ref: '847ec1c'  # migrate to herculesteam/augeasproviders_sysctl; https://github.com/duritong/puppet-sysctl/pull/48
 mod 'example42/network', git: 'https://github.com/lsst-it/puppet-network', ref: 'd5ea77e'  # allow stdlib/concat 9.x

--- a/hieradata/role/hypervisor/osfamily/RedHat/major/9.yaml
+++ b/hieradata/role/hypervisor/osfamily/RedHat/major/9.yaml
@@ -1,6 +1,48 @@
 ---
 libvirt::service::modular_services:
-  virtproxyd:
+  virtproxyd: &svc
     ensure: "running"
     enable: true
     tag: "libvirt-libvirtd-conf"
+  virtqemud.socket:
+    <<: *svc
+  virtqemud-ro.socket:
+    <<: *svc
+  virtqemud-admin.socket:
+    <<: *svc
+  virtnetworkd.socket:
+    <<: *svc
+  virtnetworkd-ro.socket:
+    <<: *svc
+  virtnetworkd-admin.socket:
+    <<: *svc
+  virtnodedevd.socket:
+    <<: *svc
+  virtnodedevd-ro.socket:
+    <<: *svc
+  virtnodedevd-admin.socket:
+    <<: *svc
+  virtnwfilterd.socket:
+    <<: *svc
+  virtnwfilterd-ro.socket:
+    <<: *svc
+  virtnwfilterd-admin.socket:
+    <<: *svc
+  virtsecretd.socket:
+    <<: *svc
+  virtsecretd-ro.socket:
+    <<: *svc
+  virtsecretd-admin.socket:
+    <<: *svc
+  virtstoraged.socket:
+    <<: *svc
+  virtstoraged-ro.socket:
+    <<: *svc
+  virtstoraged-admin.socket:
+    <<: *svc
+  virtinterfaced.socket:
+    <<: *svc
+  virtinterfaced-ro.socket:
+    <<: *svc
+  virtinterfaced-admin.socket:
+    <<: *svc

--- a/spec/hosts/roles/hypervisor_spec.rb
+++ b/spec/hosts/roles/hypervisor_spec.rb
@@ -44,6 +44,41 @@ describe "#{role} role" do
           end
 
           it { is_expected.to contain_class('tuned').with_active_profile('virtual-host') }
+
+          if facts[:os]['release']['major'] == '9'
+            %w[
+              virtproxyd
+              virtqemud.socket
+              virtqemud-ro.socket
+              virtqemud-admin.socket
+              virtnetworkd.socket
+              virtnetworkd-ro.socket
+              virtnetworkd-admin.socket
+              virtnodedevd.socket
+              virtnodedevd-ro.socket
+              virtnodedevd-admin.socket
+              virtnwfilterd.socket
+              virtnwfilterd-ro.socket
+              virtnwfilterd-admin.socket
+              virtsecretd.socket
+              virtsecretd-ro.socket
+              virtsecretd-admin.socket
+              virtstoraged.socket
+              virtstoraged-ro.socket
+              virtstoraged-admin.socket
+              virtinterfaced.socket
+              virtinterfaced-ro.socket
+              virtinterfaced-admin.socket
+            ].each do |svc|
+              it do
+                is_expected.to contain_service(svc).with(
+                  ensure: 'running',
+                  enable: true,
+                  tag: 'libvirt-libvirtd-conf',
+                )
+              end
+            end
+          end
         end # host
       end # lsst_sites
     end


### PR DESCRIPTION
libvirt startup seems to have regressed again on EL9 on newly provisioned nodes. Hopefully, pedantically enumerating the socket units will be a durable fix.