### PR TITLE
rke client version bump for dev clusters

### DIFF
--- a/hieradata/cluster/ayekan.yaml
+++ b/hieradata/cluster/ayekan.yaml
@@ -1,7 +1,7 @@
 ---
 clustershell::groupmembers:
   ayekan: {group: "ayekan", member: "ayekan[01-03]"}
-profile::core::rke::version: "1.4.6-rc4"
+profile::core::rke::version: "1.4.6"
 nm::connections:
   eno1np0:
     content: |

--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -2,7 +2,6 @@
 clustershell::groupmembers:
   ruka: {group: "ruka", member: "ruka[01-05]"}
 profile::core::rke::enable_dhcp: true
-profile::core::rke::version: "1.4.6-rc4"
 nm::connections:
   br2505:
     content: |

--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::rke::version: "1.4.6"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -45,8 +45,8 @@ class profile::core::rke (
   }
 
   $rke_checksum = $version ? {
-    '1.3.12' => '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
-    '1.4.6-rc4' => '220cdd575fcefc77ef8d7c2ff030cb8604fa484f7db5d3bcffa2cd6c794b2563',
+    '1.3.12'    => '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+    '1.4.6'     => '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -122,6 +122,25 @@ describe 'profile::core::rke' do
           end
         end
 
+        context 'when 1.4.6' do
+          let(:params) do
+            {
+              version: '1.4.6',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
+
+          it do
+            is_expected.to contain_class('rke').with(
+              version: '1.4.6',
+              checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+            )
+          end
+        end
+
         context 'when 42' do
           let(:params) do
             {

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -38,7 +38,7 @@ describe 'ayekan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.4.6-rc4',
+          version: '1.4.6',
         )
       end
 

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -22,7 +22,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
       let(:node_params) do
         {
           role: 'rke',
-          site: 'ls',
+          site: 'dev',
           cluster: 'kueyen',
         }
       end
@@ -50,7 +50,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('profile::core::rke').with(
           enable_dhcp: true,
-          version: '1.3.12',
+          version: '1.4.6',
         )
       end
 

--- a/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'namkueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.3.12',
+          version: '1.4.6',
         )
       end
 

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -55,7 +55,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('profile::core::rke').with(
           enable_dhcp: true,
-          version: '1.4.6-rc4',
+          version: '1.4.6',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -22,13 +22,6 @@ shared_examples 'generic rke' do
       .with_content(%r{^alias k='kubectl'$})
       .with_content(%r{^complete -o default -F __start_kubectl k$})
   end
-
-  it do
-    is_expected.to contain_class('rke').with(
-      version: '1.3.12',
-      checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
-    )
-  end
 end
 
 role = 'rke'
@@ -59,6 +52,13 @@ describe "#{role} role" do
 
         include_examples 'common', facts: facts
         include_examples 'generic rke'
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
       end # host
 
       fqdn = "#{role}.ls.lsst.org"
@@ -72,6 +72,13 @@ describe "#{role} role" do
 
         include_examples 'common', facts: facts
         include_examples 'generic rke'
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
       end # host
 
       fqdn = "#{role}.cp.lsst.org"
@@ -85,6 +92,13 @@ describe "#{role} role" do
 
         include_examples 'common', facts: facts
         include_examples 'generic rke'
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.3.12',
+            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          )
+        end
       end # host
 
       fqdn = "#{role}.dev.lsst.org"
@@ -98,6 +112,13 @@ describe "#{role} role" do
 
         include_examples 'common', facts: facts
         include_examples 'generic rke'
+
+        it do
+          is_expected.to contain_class('rke').with(
+            version: '1.4.6',
+            checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          )
+        end
       end # host
     end # on os
   end # on_supported_os


### PR DESCRIPTION
rke version 1.4.6 ha been set to the k8s cluster in order to bump k8s version to v1.25.9