### PR TITLE
(common) enable sssd startup of services; disable socket activation

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -341,7 +341,11 @@ sssd::main_config:
   sssd:
     config_file_version: 2
     domains: "lsst.cloud"
-    services: []
+    services:
+      - "nss"
+      - "pam"
+      - "ssh"
+      - "sudo"
   nss:
     homedir_substring: "/home"
   "domain/%{lookup('easy_ipa::domain')}":
@@ -361,6 +365,8 @@ sssd::main_config:
 sssd::package_name:
   - "sssd"
   - "sssd-tools"  # not installed by default
+sssd::service_names:
+  - "sssd"
 
 telegraf::logfile: "/dev/null"
 telegraf::quiet: true

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -136,11 +136,7 @@ class profile::core::common (
   }
 
   if $manage_sssd {
-    class { 'sssd':
-      service_names => ['sssd'],
-    }
-    # run ipa-install-* script before trying to managing sssd.conf
-    Class[easy_ipa] -> Class[sssd]
+    include profile::core::sssd
   }
 
   if $manage_krb5 {
@@ -155,7 +151,6 @@ class profile::core::common (
 
   if $manage_ipa {
     include profile::core::ipa
-    Class[easy_ipa] -> Class[profile::core::ipa]
   }
 
   if $disable_ipv6 {

--- a/site/profile/manifests/core/ipa.pp
+++ b/site/profile/manifests/core/ipa.pp
@@ -8,6 +8,8 @@
 class profile::core::ipa (
   Optional[Hash] $default = undef,
 ) {
+  require easy_ipa
+
   $param_defaults = {
     'path'  => '/etc/ipa/default.conf',
     require => Class[easy_ipa],

--- a/site/profile/manifests/core/sssd.pp
+++ b/site/profile/manifests/core/sssd.pp
@@ -1,0 +1,35 @@
+# @summary
+#   Common functionality needed by standard nodes.
+#
+class profile::core::sssd {
+  require easy_ipa
+  contain sssd
+
+  if fact('os.family') == 'RedHat' {
+    # disable sssd socket activation and services which should be started by
+    # sssd
+    [
+      'sssd-autofs',
+      'sssd-autofs.socket',
+      'sssd-kcm',
+      'sssd-kcm.socket',
+      'sssd-nss',
+      'sssd-nss.socket',
+      'sssd-pac',
+      'sssd-pac.socket',
+      'sssd-pam',
+      'sssd-pam-priv.socket',
+      'sssd-pam.socket',
+      'sssd-ssh',
+      'sssd-ssh.socket',
+      'sssd-sudo',
+      'sssd-sudo.socket',
+    ].each |String $unit| {
+      service { $unit:
+        ensure  => stopped,
+        enable  => false,
+        require => Class['sssd'],
+      }
+    }
+  }
+}

--- a/spec/classes/archive/commmon_spec.rb
+++ b/spec/classes/archive/commmon_spec.rb
@@ -6,6 +6,12 @@ describe 'profile::archive::common' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let(:pre_condition) do
+        <<~PP
+          # easy_ipa has a hardwired dep on the sssd service
+          class { 'sssd': service_names => ['sssd'] }
+        PP
+      end
 
       it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -6,6 +6,12 @@ describe 'profile::core::common' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let(:pre_condition) do
+        <<~PP
+          # easy_ipa has a hardwired dep on the sssd service
+          class { 'sssd': service_names => ['sssd'] }
+        PP
+      end
 
       context 'with no params' do
         it { is_expected.to compile.with_all_deps }

--- a/spec/classes/core/sssd_spec.rb
+++ b/spec/classes/core/sssd_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::sssd' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) do
+        <<~PP
+          # easy_ipa has a hardwired dep on the sssd service
+          class { 'sssd': service_names => ['sssd'] }
+        PP
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'sssd services'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -157,6 +157,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true, network: true
     include_examples 'krb5.conf content', %r{default_ccache_name = FILE:/tmp/krb5cc_%{uid}}
 
     include_examples 'krb5.conf.d files', facts: facts
+    include_examples 'sssd services'
 
     it do
       # XXX dev is using ls ipa servers
@@ -211,7 +212,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true, network: true
           [sssd]
           config_file_version=2
           domains=lsst.cloud
-          services=
+          services=nss, pam, ssh, sudo
 
           [domain/lsst.cloud]
           access_provider=ipa
@@ -243,7 +244,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true, network: true
           [sssd]
           config_file_version=2
           domains=lsst.cloud
-          services=
+          services=nss, pam, ssh, sudo
 
           [domain/lsst.cloud]
           access_provider=ipa
@@ -1264,5 +1265,7 @@ shared_examples 'fog_hack' do
     ).that_requires('Package[libvirt-devel]')
   end
 end
+
+Dir['./spec/support/spec/**/*.rb'].sort.each { |f| require f }
 
 # 'spec_overrides' from sync.yml will appear below this line

--- a/spec/support/spec/sssd.rb
+++ b/spec/support/spec/sssd.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+shared_examples 'sssd services' do
+  it do
+    is_expected.to contain_class('sssd').with_service_names(['sssd'])
+                                        .that_requires('Class[easy_ipa]')
+  end
+
+  it do
+    is_expected.to contain_service('sssd').with(
+      ensure: 'running',
+      enable: true,
+    )
+  end
+
+  %w[
+    sssd-autofs
+    sssd-autofs.socket
+    sssd-kcm
+    sssd-kcm.socket
+    sssd-nss
+    sssd-nss.socket
+    sssd-pac
+    sssd-pac.socket
+    sssd-pam
+    sssd-pam-priv.socket
+    sssd-pam.socket
+    sssd-ssh
+    sssd-ssh.socket
+    sssd-sudo
+    sssd-sudo.socket
+  ].each do |unit|
+    it do
+      is_expected.to contain_service(unit).with(
+        ensure: 'stopped',
+        enable: false,
+      )
+                                          .that_requires('Class[sssd]')
+                                          .that_requires('Class[easy_ipa]')
+    end
+  end
+end


### PR DESCRIPTION
`bodgit/sssd` was enabling systemd socket unit activation for sssd sub-services while the puppet/sssd module does not.  This created a problem as the `sssd.conf` was setup of socket activation.  As we were unable to get sssd socket activation to work as expeected on EL9.2 (odd).  Thus, we are reverting to sssd driven activation of sssd sub-services, which is consitent with the configuration created by `ipa-client-install`.