### PR TITLE
(profile::core::puppet_master) fix pc_repo description string

### DIFF
--- a/site/profile/manifests/core/foreman.pp
+++ b/site/profile/manifests/core/foreman.pp
@@ -146,7 +146,7 @@ class profile::core::foreman (
   yumrepo { 'pc_repo':
     ensure   => 'present',
     baseurl  => "http://yum.puppet.com/puppet7/el/${fact('os.release.major')}/x86_64",
-    descr    => 'Puppet Labs puppet6 Repository',
+    descr    => 'Puppet Labs puppet7 Repository',
     enabled  => true,
     gpgcheck => '1',
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet\n  file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406",


### PR DESCRIPTION
The repo was being labled as "Puppet Labs puppet6 Repository" when it was being (correctly) configured to use the puppet7 repo.