### PR TITLE
(.puppet-lint.rc) disable legacy_facts check

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,2 @@
 --relative
+--no-legacy_facts

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'simplecov-console',         require: false
   gem 'voxpupuli-test', '~> 5.4',  require: false
 
-  gem 'puppet-lint-legacy_facts-check', '~> 1.0.4',            require: false
   gem 'puppet-lint-no_erb_template-check', '~> 1.0.0',         require: false
   gem 'puppet-lint-optional_default-check',                    require: false
   gem 'puppet-lint-package_ensure-check', '~> 0.2.0',          require: false


### PR DESCRIPTION
This will need to be re-enabled/resolved in order to migrate to puppet8.