### PR TITLE
(profile::core::hard) manage bmc on SSG-640SP-E1CR90

### DIFF
--- a/site/profile/manifests/core/hardware.pp
+++ b/site/profile/manifests/core/hardware.pp
@@ -30,6 +30,9 @@ class profile::core::hardware {
         }
       }
     }
+    /SSG-640SP-E1CR90/: {
+      include ipmi
+    }
   }
 
   # On SM H12SSL-NT dmi.product.name == "Super Server", which isn't very helpful

--- a/spec/classes/core/hardware_spec.rb
+++ b/spec/classes/core/hardware_spec.rb
@@ -86,6 +86,21 @@ describe 'profile::core::hardware' do
         it { is_expected.not_to contain_class('profile::core::kernel::nvme_apst') }
         it { is_expected.not_to contain_profile__util__kernel_param('pci=pcie_bus_perf') }
       end  # H12SSL-NT
+
+      context 'with SSG-640SP-E1CR90' do
+        let(:facts) do
+          super().merge(
+            dmi: {
+              product: {
+                name: 'SSG-640SP-E1CR90',
+              },
+            },
+          )
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ipmi') }
+      end  # SSG-640SP-E1CR90
     end
   end
 end


### PR DESCRIPTION
+ resolve a strange test failure in the chango01.ls.lsst.org spec seen with the prometheus module:

```
     # Puppet::ParseError:
     #   Class[Prometheus]: parameter 'init_style' expects a match for Prometheus::Initstyle = Enum['launchd', 'none', 'sles', 'systemd', 'sysv', 'upstart'], got Undef
     #   ./.bundle/ruby/2.7.0/gems/puppet-7.26.0/lib/puppet/pops/types/type_mismatch_describer.rb:536:in `validate_parameters'
```