### PR TITLE
(*) Capitalize bare words used to ref class names

### DIFF
--- a/hieradata/role/perfsonar.yaml
+++ b/hieradata/role/perfsonar.yaml
@@ -56,7 +56,7 @@ files:
   # perfsonar packaging installs this one file with the wrong mode
   "/etc/sudoers.d/perfsonar_sudo":
     mode: "0440"
-    require: "Class[perfsonar]"
+    require: "Class[Perfsonar]"
 
 # The perfsonar class does not allow a pS version to be set.
 # The yumrepo mirror list used:

--- a/site/profile/manifests/ccs/postfix.pp
+++ b/site/profile/manifests/ccs/postfix.pp
@@ -19,5 +19,5 @@ class profile::ccs::postfix (
   }
 
   ensure_packages($packages)
-  Package[$packages] -> Class[postfix]
+  Package[$packages] -> Class['postfix']
 }

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -151,7 +151,7 @@ class profile::core::common (
     include profile::core::ipa
 
     # prevent ipa packages from being installed before versionlocks are set
-    Yum::Versionlock<| |> -> Class[ipa]
+    Yum::Versionlock<| |> -> Class['ipa']
 
     # run ipa-install-* script before X
     Class[ipa] -> Class[ssh]

--- a/site/profile/manifests/core/ipa.pp
+++ b/site/profile/manifests/core/ipa.pp
@@ -12,7 +12,7 @@ class profile::core::ipa (
 
   $param_defaults = {
     'path'  => '/etc/ipa/default.conf',
-    require => Class[ipa],
+    require => Class['ipa'],
   }
 
   if $default {

--- a/site/profile/manifests/core/krb5.pp
+++ b/site/profile/manifests/core/krb5.pp
@@ -6,7 +6,7 @@ class profile::core::krb5 {
   include mit_krb5
 
   # run ipa-install-* script before trying to managing krb5.conf
-  Class[ipa] -> Class[mit_krb5]
+  Class['ipa'] -> Class['mit_krb5']
 
   # create /etc/krb5.conf.d files only on EL8+
   unless fact('os.family') == 'RedHat' and fact('os.release.major') == '7' {

--- a/site/profile/manifests/core/nm_dispatch.pp
+++ b/site/profile/manifests/core/nm_dispatch.pp
@@ -15,8 +15,8 @@ class profile::core::nm_dispatch (
       # if restart is configured to be only per interface... needs some experimentation
       #$network_notify = "Exec[network_restart_${dev}]"
       $network_notify = fact('os.release.major') ? {
-        '7'     => 'Class[network]',
-        default => 'Class[nm]',
+        '7'     => 'network',
+        default => 'nm',
       }
 
       $data = {
@@ -28,7 +28,7 @@ class profile::core::nm_dispatch (
         ensure  => file,
         content => epp("${module_name}/core/nm_interface/50-dev.epp", $data),
         mode    => '0755',
-        notify  => $network_notify,
+        notify  => Class[$network_notify],
       }
     }
   }

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -30,7 +30,7 @@ class profile::core::rke (
     profile::util::keytab { $user:
       uid           => $uid,
       keytab_base64 => $keytab_base64,
-      require       => Class[ipa], # ipa must be setup to use the rke user
+      require       => Class['ipa'], # ipa must be setup to use the rke user
     }
   }
 
@@ -42,7 +42,7 @@ class profile::core::rke (
     user               => $user,
     owner              => $user,
     group              => $user,
-    require            => Class[ipa], # ipa must be setup to use the rke user
+    require            => Class['ipa'], # ipa must be setup to use the rke user
   }
 
   $rke_checksum = $version ? {

--- a/site/profile/manifests/core/sssd.pp
+++ b/site/profile/manifests/core/sssd.pp
@@ -5,7 +5,7 @@ class profile::core::sssd {
   require ipa
   contain sssd
 
-  Class[ipa] -> Class[sssd]
+  Class['ipa'] -> Class['sssd']
 
   if fact('os.family') == 'RedHat' {
     # disable sssd socket activation and services which should be started by
@@ -30,7 +30,7 @@ class profile::core::sssd {
       service { $unit:
         ensure  => stopped,
         enable  => false,
-        require => Class[sssd],
+        require => Class['sssd'],
       }
     }
   }


### PR DESCRIPTION
Bare string handling in puppet is bazaar...

Resolves these errors:

```
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Invalid relationship: File[/etc/sudoers.d/perfsonar_sudo] { require => Class[perfsonar] }, because Class[perfsonar] doesn't seem to be in the catalog
```

```
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Invalid relationship: File[/etc/NetworkManager/dispatcher.d/50-eno1] { notify => Class[network] }, because Class[network] doesn't seem to be in the catalog
```