### PR TITLE
(role/hypervisor) on EL9, do not enforce virtproxyd as running

### DIFF
--- a/hieradata/role/hypervisor/osfamily/RedHat/major/9.yaml
+++ b/hieradata/role/hypervisor/osfamily/RedHat/major/9.yaml
@@ -1,11 +1,14 @@
 ---
 libvirt::service::modular_services:
-  virtproxyd: &svc
+  virtproxyd:
+    # The virtproxyd service should be enabled but puppet should not enforce
+    # that it is running as it is socket activated and will shutdown when idle.
+    enable: true
+    tag: "libvirt-libvirtd-conf"
+  virtqemud.socket: &svc
     ensure: "running"
     enable: true
     tag: "libvirt-libvirtd-conf"
-  virtqemud.socket:
-    <<: *svc
   virtqemud-ro.socket:
     <<: *svc
   virtqemud-admin.socket:

--- a/spec/hosts/roles/hypervisor_spec.rb
+++ b/spec/hosts/roles/hypervisor_spec.rb
@@ -43,8 +43,14 @@ describe "#{role} role" do
           it { is_expected.to contain_class('tuned').with_active_profile('virtual-host') }
 
           if facts[:os]['release']['major'] == '9'
+            it do
+              is_expected.to contain_service('virtproxyd').with(
+                enable: true,
+                tag: 'libvirt-libvirtd-conf',
+              )
+            end
+
             %w[
-              virtproxyd
               virtqemud.socket
               virtqemud-ro.socket
               virtqemud-admin.socket


### PR DESCRIPTION
Resolves the agent showing activity on every run as virtproxyd is socket activated and shuts down when idle.

    ensure changed 'stopped' to 'running' (corrective)