### PR TITLE
(common) purge telegraf config fragments; disable ethtool plugin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -400,7 +400,6 @@ telegraf::inputs:
   nstat: [{}]
   swap: [{}]
   system: [{}]
-  ethtool: [{}]
   kernel: [{}]
   kernel_vmstat: [{}]
   netstat: [{}]

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -387,6 +387,7 @@ sssd::service_names:
 
 telegraf::quiet: true
 telegraf::hostname: "%{facts.networking.fqdn}"
+telegraf::purge_config_fragments: true
 telegraf::inputs:
   cpu:
     - percpu: true

--- a/spec/support/spec/telegraf.rb
+++ b/spec/support/spec/telegraf.rb
@@ -14,4 +14,6 @@ shared_examples 'telegraf' do
       }],
     )
   end
+
+  it { is_expected.to contain_file('/etc/telegraf/telegraf.d').with_purge(true) }
 end


### PR DESCRIPTION
This is an attempt to resolve numerous error messages being logged by telegraf.