### PR TITLE
(role/atshcu) bump imanager version

### DIFF
--- a/hieradata/role/atshcu.yaml
+++ b/hieradata/role/atshcu.yaml
@@ -16,7 +16,7 @@ ccs_hcu::vldrive::module: "versaapi"
 ccs_hcu::vldrive::version: "1.5.0"
 
 ccs_hcu::imanager::module: "imanager"
-ccs_hcu::imanager::version: "1.5.0"
+ccs_hcu::imanager::version: "1.5.1"
 
 nfs::client_enabled: true
 nfs::client_mounts:


### PR DESCRIPTION
Imanager version 1.5.1 compiles on rhel9 (as well as rhel7).
It is safe to bump this globally because nowhere is actually using puppet to install this module at present.
