### PR TITLE
(role/{ess,lasterrpi}) rm profile::ts::rpi

### DIFF
--- a/hieradata/role/ess.yaml
+++ b/hieradata/role/ess.yaml
@@ -5,7 +5,6 @@ classes:
   - "profile::core::gpio"
   - "profile::core::i2c"
   - "profile::pi::config"
-  - "profile::ts::rpi"
 
 # disabling the kernel version check is needed on el7
 docker::overlay2_override_kernel_check: true

--- a/hieradata/role/laserrpi.yaml
+++ b/hieradata/role/laserrpi.yaml
@@ -3,7 +3,6 @@ classes:
   - "profile::core::common"
   - "profile::core::docker"
   - "profile::core::gpio"
-  - "profile::ts::rpi"
 
 # disabling the kernel version check is needed on el7
 docker::overlay2_override_kernel_check: true


### PR DESCRIPTION
The `profile::ts::rpi` appears to be a mix of configuration that should both be broken up into multiple profiles and should not be applied to all pis.