### PR TITLE
(common) bump puppet agent/server to 7.27.0/7.14.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -259,7 +259,7 @@ selinux::mode: "disabled"
 # Stop iptables by default - the default rules are highly restrictive to the
 # point of harm and we don't have a meaningful permission set to make this useful.
 firewall::ensure: "stopped"
-puppet_agent::package_version: "7.21.0"
+puppet_agent::package_version: "7.27.0"
 puppet_agent::collection: "puppet7"
 puppet_agent::config:
   - {section: "agent", setting: "environment", ensure: "absent"}

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -172,7 +172,7 @@ puppet::server_jvm_max_heap_size: &jvm_heap "5G"  # (max-act-inst * 0.5G) + 1G
 puppet::server_jvm_min_heap_size: *jvm_heap
 puppet::server_jvm_extra_args: ["-XX:ReservedCodeCacheSize=1G", "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"]
 puppet::server::puppetdb::soft_write_failure: true
-puppet::server_puppetserver_version: &server_version "7.9.3"
+puppet::server_puppetserver_version: &server_version "7.14.0"
 puppet::server_reports: "foreman,puppetdb"
 puppet::server_storeconfigs: true
 puppet::server: true

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,7 @@
 #  yamllint disable rule:quoted-strings
 sudoversion: "1.8.23"
 snmp_community: "MhcZxm00k6GjpRedxFnnxA"  #  lsst/ccs_mrtg
-aio_agent_version: "7.21.0"  #  puppetlabs/puppet_agent
+aio_agent_version: "7.27.0"  #  puppetlabs/puppet_agent
 grub_version: "grub2-mkconfig (GRUB) 2.02~beta2"  # simp/auditd
 ipmitool_mc_info:
   IPMI_Puppet_Service_Recommend: "running"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,9 @@ include RspecPuppetFacts
 
 # foreman, puppetserver and termini versions
 FOREMAN_VERSION = '3.2.1'
-PUPPETSERVER_VERSION = '7.9.3'
-TERMINI_VERSION = '7.14.0'
+PUPPETAGENT_VERSION = '7.27.0'
+PUPPETSERVER_VERSION = '7.14.0'
+TERMINI_VERSION = PUPPETSERVER_VERSION
 
 # facterdb does not include puppetlabs/stdlib facts
 add_stdlib_facts
@@ -279,7 +280,7 @@ shared_examples 'common' do |os_facts:, no_auth: false, chrony: true, network: t
   if os_facts[:os]['family'] == 'RedHat'
     it { is_expected.to contain_class('epel') }
     it { is_expected.to contain_class('yum::plugin::versionlock').with_clean(true) }
-    it { is_expected.to contain_yum__versionlock('puppet-agent').with_version('7.21.0') }
+    it { is_expected.to contain_yum__versionlock('puppet-agent').with_version(PUPPETAGENT_VERSION) }
     it { is_expected.to contain_class('yum').with_manage_os_default_repos(true) }
     it { is_expected.to contain_resources('yumrepo').with_purge(true) }
     it { is_expected.to contain_class('profile::core::yum') }


### PR DESCRIPTION
This is motivated by 7.27.0 declaring support for el9 on arm64.

See: https://www.puppet.com/docs/puppet/7/release_notes_puppet.html#release_notes_puppet_x-7-27-0

Agent tested on EL7 & EL9. Server tested on EL7.