### PR TITLE
(profile::core::gpio) restrict libgpiod-utils to el9

### DIFF
--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -284,8 +284,5 @@ profile::core::dtn::packages:
   - "hwloc"
   - "hwloc-gui"
 
-profile::core::gpio::packages:
-  - "libgpiod-utils"
-
 profile::core::i2c::packages:
   - "i2c-tools"

--- a/site/profile/data/osfamily/RedHat/major/9.yaml
+++ b/site/profile/data/osfamily/RedHat/major/9.yaml
@@ -39,3 +39,6 @@ profile::core::docker::versionlock:
     ensure: "present"
     version: "2.17.3"
     release: *docker_release
+
+profile::core::gpio::packages:
+  - "libgpiod-utils"

--- a/spec/classes/core/gpio_spec.rb
+++ b/spec/classes/core/gpio_spec.rb
@@ -9,7 +9,7 @@ describe 'profile::core::gpio' do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'gpio'
+      include_examples 'gpio', os_facts: os_facts
     end
   end
 end

--- a/spec/hosts/roles/atshcu_spec.rb
+++ b/spec/hosts/roles/atshcu_spec.rb
@@ -27,9 +27,8 @@ describe "#{role} role" do
           include_examples 'common', os_facts: os_facts
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
+          include_examples 'gpio', os_facts: os_facts
           it { is_expected.to contain_class('ccs_hcu') }
-
-          include_examples 'gpio'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/ess_spec.rb
+++ b/spec/hosts/roles/ess_spec.rb
@@ -34,7 +34,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', os_facts: os_facts
-          include_examples 'gpio'
+          include_examples 'gpio', os_facts: os_facts
           include_examples 'i2c', os_facts: os_facts
           include_examples 'ftdi'
           include_examples 'rubinhat'

--- a/spec/support/spec/gpio.rb
+++ b/spec/support/spec/gpio.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'gpio' do
+shared_examples 'gpio' do |os_facts:|
   it do
     is_expected.to contain_systemd__udev__rule('gpio.rules').with(
       rules: [
@@ -17,5 +17,9 @@ shared_examples 'gpio' do
     )
   end
 
-  it { is_expected.to contain_package('libgpiod-utils') }
+  if os_facts[:os]['family'] == 'RedHat' && os_facts[:os]['release']['major'] == '9'
+    it { is_expected.to contain_package('libgpiod-utils') }
+  else
+    it { is_expected.not_to contain_package('libgpiod-utils') }
+  end
 end


### PR DESCRIPTION
As this package is not present on el7.