### PR TITLE
(spec) fix spec failures seen under gha

### DIFF
--- a/spec/classes/core/foreman_spec.rb
+++ b/spec/classes/core/foreman_spec.rb
@@ -7,6 +7,13 @@ describe 'profile::core::foreman' do
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) { { smee_url: 'https://foo.example.org' } }
+      let(:pre_condition) do
+        <<~PP
+        class { 'puppet':
+          environment => 'production',
+        }
+        PP
+      end
 
       it { is_expected.to compile.with_all_deps }
 


### PR DESCRIPTION
Resolves the failure below which seems to only under appear under gha. It is suspected that this is related to a change in behavior for the $server_facts hash but there's currently no explanation as to why is a gha specific phenomena.

    Failure/Error: it { is_expected.to compile.with_all_deps }
      error during compilation: Evaluation Error: Error while evaluating a Function Call, Class[Puppet]: parameter 'environment' expects a String value, got Undef (file: /home/runner/work/lsst-control/lsst-control/site/profile/manifests/core/foreman.pp, line: 50, column: 3) on node runner.c4nt51ssv0detdtscamcazwz5h.xx.internal.cloudapp.net