### PR TITLE
(foreman.cp) add dhcp pool vlan1609 TMA-Network

### DIFF
--- a/hieradata/node/foreman.cp.lsst.org.yaml
+++ b/hieradata/node/foreman.cp.lsst.org.yaml
@@ -123,6 +123,13 @@ dhcp::pools:
     range:
       - "139.229.170.64 139.229.170.191"  # ~/25
     search_domains: "%{alias('dhcp::dnsdomain')}"
+  TMA-Network:
+    network: "139.229.171.0"
+    mask: "255.255.255.0"
+    gateway: "139.229.171.254"
+    range:
+      - "139.229.171.150 139.229.171.180"
+    search_domains: "%{alias('dhcp::dnsdomain')}"
   CCS-Pathfinder:
     network: "139.229.174.0"
     mask: "255.255.255.0"

--- a/spec/hosts/nodes/foreman.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/foreman.cp.lsst.org_spec.rb
@@ -185,6 +185,15 @@ describe 'foreman.cp.lsst.org', :sitepp do
       end
 
       it do
+        is_expected.to contain_dhcp__pool('TMA-Network').with(
+          network: '139.229.171.0',
+          mask: '255.255.255.0',
+          range: ['139.229.171.150 139.229.171.180'],
+          gateway: '139.229.171.254',
+        )
+      end
+
+      it do
         is_expected.to contain_dhcp__pool('CCS-Pathfinder').with(
           network: '139.229.174.0',
           mask: '255.255.255.0',


### PR DESCRIPTION
A new DHCP pool was created for VLAN1609 (TMA Network). Test and IPAM were updated to reflect these changes.

The subnet already existed so this is to create a DHCP pool far away from the already static IPs on the TMA network. Also, this is to create the FQDNs of all existent devices inside that subsystem. 