### PR TITLE
(cluster/comcam-ccs) packages rh-git218 and devtoolset-8 are rhel7 only

### DIFF
--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -1,8 +1,4 @@
 ---
-packages:
-  - "devtoolset-8"
-  - "rh-git218"
-
 postfix::manage_root_alias: false
 postfix::inet_protocols: "ipv4"
 postfix::inet_interfaces: "localhost"

--- a/hieradata/cluster/comcam-ccs/osfamily/RedHat/major/7.yaml
+++ b/hieradata/cluster/comcam-ccs/osfamily/RedHat/major/7.yaml
@@ -1,3 +1,7 @@
 ---
+packages:
+  - "devtoolset-8"
+  - "rh-git218"
+
 ccs_sal::rpms_private:
   OpenSpliceDDS: "OpenSpliceDDS-6.10.4-6.el7.x86_64.rpm"


### PR DESCRIPTION
This change was already implemented for lsstcam and auxtel.