### PR TITLE
(cp/role/nfsserver) add rsphome share for nublado

### DIFF
--- a/hieradata/site/cp/role/nfsserver.yaml
+++ b/hieradata/site/cp/role/nfsserver.yaml
@@ -77,6 +77,13 @@ nfs::nfs_exports_global:
       139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.191.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)
+  /data/rsphome:
+    # nublado needs to be able to create user home dirs as root
+    clients: >-
+      %{facts.networking.ip}/32(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
+      nfs2.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
 
 files:
   /data/project:
@@ -130,5 +137,9 @@ nfs::client_mounts:
     atboot: true
   /net/self/dimm:
     share: "dimm"
+    server: "%{facts.fqdn}"
+    atboot: true
+  /net/self/data/rsphome:
+    share: "rsphome"
     server: "%{facts.fqdn}"
     atboot: true

--- a/spec/hosts/roles/nfsserver_spec.rb
+++ b/spec/hosts/roles/nfsserver_spec.rb
@@ -128,6 +128,23 @@ describe "#{role} role" do
         end
 
         it do
+          expect(catalogue.resource('nfs::server::export', '/data/rsphome')[:clients])
+            .to include(
+              '139.229.146.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
+              '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+              'nfs2.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+            )
+        end
+
+        it do
+          is_expected.to contain_nfs__client__mount('/net/self/data/rsphome').with(
+            share: 'rsphome',
+            server: facts[:fqdn],
+            atboot: true,
+          )
+        end
+
+        it do
           is_expected.to contain_nfs__client__mount('/net/self/data/project').with(
             share: 'project',
             server: facts[:fqdn],


### PR DESCRIPTION
A new NFS was requested to replace jhome on the new instance of Nublado for the summit.