### PR TITLE
Add stationary /dev/serial* symlinks

### DIFF
--- a/site/profile/manifests/pi/rubinhat.pp
+++ b/site/profile/manifests/pi/rubinhat.pp
@@ -30,6 +30,11 @@ class profile::pi::rubinhat {
     rules => [
       "KERNEL==\"ttyS[0-9]*\", GROUP=\"${group}\", MODE=\"0660\"",
       "KERNEL==\"ttyAMA[0-9]*\", GROUP=\"${group}\", MODE=\"0660\"",
+      "ATTR{iomem_base}==\"0xFE201000\", SYMLINK:=\"serial0\"",
+      "ATTR{iomem_base}==\"0xFE201400\", SYMLINK:=\"serial1\"",
+      "ATTR{iomem_base}==\"0xFE201600\", SYMLINK:=\"serial2\"",
+      "ATTR{iomem_base}==\"0xFE201800\", SYMLINK:=\"serial3\"",
+      "ATTR{iomem_base}==\"0xFE201A00\", SYMLINK:=\"serial4\"",
     ],
   }
 }

--- a/spec/support/spec/rubinhat.rb
+++ b/spec/support/spec/rubinhat.rb
@@ -23,6 +23,11 @@ shared_examples 'rubinhat' do
       rules: [
         'KERNEL=="ttyS[0-9]*", GROUP="70014", MODE="0660"',
         'KERNEL=="ttyAMA[0-9]*", GROUP="70014", MODE="0660"',
+        'ATTR{iomem_base}=="0xFE201000", SYMLINK:="serial0"',
+        'ATTR{iomem_base}=="0xFE201400", SYMLINK:="serial1"',
+        'ATTR{iomem_base}=="0xFE201600", SYMLINK:="serial2"',
+        'ATTR{iomem_base}=="0xFE201800", SYMLINK:="serial3"',
+        'ATTR{iomem_base}=="0xFE201A00", SYMLINK:="serial4"',
       ],
     )
   end


### PR DESCRIPTION
Adds to existing udev script for rubin pi units -- creates `/dev/serial*` symlinks that are linked to actual hardware resources on the Broadcom chip.  We can use these in higher level software instead of `/dev/ttyAMA*`, and be sure they won't move around between kernel releases.