### PR TITLE
(common) rm telegraf from all hosts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -400,33 +400,8 @@ sssd::package_name:
 sssd::service_names:
   - "sssd"
 
-telegraf::quiet: true
-telegraf::hostname: "%{facts.networking.fqdn}"
+telegraf::ensure: "absent"
 telegraf::purge_config_fragments: true
-telegraf::inputs:
-  cpu:
-    - percpu: true
-      totalcpu: true
-  mem: [{}]
-  disk: [{}]
-  diskio: [{}]
-  net:
-    - ignore_protocol_stats: true
-  nstat: [{}]
-  swap: [{}]
-  system: [{}]
-  kernel: [{}]
-  kernel_vmstat: [{}]
-  netstat: [{}]
-  processes: [{}]
-telegraf::outputs:
-  http:
-    - url: "https://mimir.o11y.dev.lsst.org/api/v1/push"
-      data_format: "prometheusremotewrite"
-      headers:
-        Content-Type: "application/x-protobuf"
-        Content-Encoding: "snappy"
-        X-Prometheus-Remote-Write-Version: "0.1.0"
 
 mit_krb5::includedir:
   - "/etc/krb5.conf.d/"

--- a/spec/support/spec/telegraf.rb
+++ b/spec/support/spec/telegraf.rb
@@ -2,16 +2,8 @@
 
 shared_examples 'telegraf' do
   it do
-    is_expected.to contain_class('telegraf').with_outputs(
-      'http' => [{
-        'url' => 'https://mimir.o11y.dev.lsst.org/api/v1/push',
-        'data_format' => 'prometheusremotewrite',
-        'headers' => {
-          'Content-Type' => 'application/x-protobuf',
-          'Content-Encoding' => 'snappy',
-          'X-Prometheus-Remote-Write-Version' => '0.1.0',
-        },
-      }],
+    is_expected.to contain_class('telegraf').with(
+      ensure: 'absent',
     )
   end
 


### PR DESCRIPTION
This is first step in migrating away from telegraf that uninstalls telegraf from all hosts.  The second step will be to rm the telegraf puppet module and supporting code from the control repo.