### PR TITLE
(node/comcam-hcu03) set imanager true

### DIFF
--- a/hieradata/node/comcam-hcu03.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-hcu03.cp.lsst.org.yaml
@@ -1,6 +1,9 @@
 ---
 ccs_hcu::filter_changer: true
 
+ccs_hcu::imanager: true
+ccs_hcu::imanager::version: "1.5.1"
+
 ccs_software::services:
   prod:
     - "bonn-shutter"


### PR DESCRIPTION
It seems that imanager had been installed by hand on comcam-hcu03, and for some reason stopped working recently.
Letting puppet manage imanager fixes this.