### PR TITLE
It 5068 daq v8.2

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V8.1"
+daq::daqsdk::version: "R5-V8.2"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients

--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V6.7"
+daq::daqsdk::version: "R5-V8.1"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients

--- a/hieradata/site/ls/role/daq-mgt.yaml
+++ b/hieradata/site/ls/role/daq-mgt.yaml
@@ -2,5 +2,3 @@
 dhcp::dnsdomain: []  # ignore site value & mod default
 dhcp::nameservers: ~  # ignore site value
 dhcp::ntpservers: ~  # ignore site value
-
-#daq::daqsdk::version: "R5-V6.7"

--- a/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'auxtel-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.2') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('auxtel-sm').with_ip('192.168.101.2') }
       it { is_expected.to contain_network__interface('p3p1').with_ensure('absent') }

--- a/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'auxtel-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('auxtel-sm').with_ip('192.168.101.2') }
       it { is_expected.to contain_network__interface('p3p1').with_ensure('absent') }

--- a/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'comcam-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('comcam-sm').with_ip('10.0.0.212') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }

--- a/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-daq-mgt-cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'comcam-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.2') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('comcam-sm').with_ip('10.0.0.212') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }

--- a/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'daq-mgt.tu.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.2') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('tts-sm').with_ip('10.0.0.212') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }

--- a/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/daq-mgt.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'daq-mgt.tu.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V6.7') }
+      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.1') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('tts-sm').with_ip('10.0.0.212') }
       it { is_expected.to contain_network__interface('p2p1').with_ensure('absent') }


### PR DESCRIPTION
In the end, there was a bug and V8.1 became V8.2. 

The puppet changes that were added in [IT-4661] mean that this can be deployed to production and the DAQ release won't be switched to automatically, so full speed ahead.