### PR TITLE
(gis-bastion01.cp) EL9 redeployment of GIS-Bastion01

### DIFF
--- a/hieradata/node/gis-bastion01.cp.lsst.org.yaml
+++ b/hieradata/node/gis-bastion01.cp.lsst.org.yaml
@@ -1,15 +1,29 @@
 ---
-network::interfaces_hash:
-  enp1s0f0:  # fqdn
-    bootproto: "dhcp"
-    defroute: "yes"
-    nozeroconf: "yes"
-    onboot: "yes"
-    type: "Ethernet"
-  enp1s0f1:  # GIS Private Network
-    bootproto: "none"
-    ipaddress: "192.168.180.230"
-    netmask: "255.255.255.0"
-    nozeroconf: "yes"
-    onboot: "yes"
-    type: "Ethernet"
+nm::connections:
+  enp1s0f0:
+    content:
+      connection:
+        id: "enp1s0f0"
+        uuid: "03da7500-2101-c722-2438-d0d006c28c73"
+        type: "ethernet"
+        interface-name: "enp1s0f0"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}
+  enp1s0f1:
+    content:
+      connection:
+        id: "enp1s0f1"
+        uuid: "da97db8e-6400-4cca-9334-71995eb2ac1d"
+        type: "ethernet"
+        interface-name: "enp1s0f1"
+      ethernet: {}
+      ipv4:
+        method: "manual"
+        address1: "192.168.180.230/24"
+      ipv6:
+        method: "disabled"
+      proxy: {}

--- a/spec/hosts/nodes/gis-bastion01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gis-bastion01.cp.lsst.org_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 
 describe 'gis-bastion01.cp.lsst.org', :sitepp do
   on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
     context "on #{os}" do
       let(:facts) do
         override_facts(os_facts,
@@ -26,28 +28,26 @@ describe 'gis-bastion01.cp.lsst.org', :sitepp do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'baremetal'
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(2) }
 
-      if os_facts[:os]['release']['major'] == '7'
-        it do
-          is_expected.to contain_network__interface('enp1s0f0').with(
-            bootproto: 'dhcp',
-            defroute: 'yes',
-            nozeroconf: 'yes',
-            onboot: 'yes',
-            type: 'Ethernet',
-          )
-        end
+      context 'with enp1s0f0' do
+        let(:interface) { 'enp1s0f0' }
 
-        it do
-          is_expected.to contain_network__interface('enp1s0f1').with(
-            bootproto: 'none',
-            ipaddress: '192.168.180.230',
-            netmask: '255.255.255.0',
-            nozeroconf: 'yes',
-            onboot: 'yes',
-            type: 'Ethernet',
-          )
-        end
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm dhcp interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+      end
+
+      context 'with enp1s0f1' do
+        let(:interface) { 'enp1s0f1' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('192.168.180.230/24') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
       end
     end # on os
   end # on_supported_os


### PR DESCRIPTION
This PR is to redeploy gis-bastion01.cp.lsst.org with Alma Linux 9 as part of the OS migration process. 