### PR TITLE
(node/comcam-mcm.{cp,tu}) add lockmanager service

### DIFF
--- a/hieradata/node/comcam-mcm.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.cp.lsst.org.yaml
@@ -44,6 +44,7 @@ ccs_software::services:
     - "mmm"
     - "comcam-mmm"
     - "cluster-monitor"
+    - "lockmanager"
 ## Next two are handled by the ccs_sal module. FIXME duplication.
 #    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
 #    - "comcam-ocs-bridge"

--- a/hieradata/node/comcam-mcm.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.tu.lsst.org.yaml
@@ -42,6 +42,7 @@ ccs_software::services:
     - "mmm"
     - "comcam-mmm"
     - "cluster-monitor"
+    - "lockmanager"
 ## Next two are handled by the ccs_sal module. FIXME duplication.
 #    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
 #    - "comcam-ocs-bridge"


### PR DESCRIPTION
It seems that this service was previously added by hand to both systems.

Ideally the service specification would move to the ccs-mcm role, but at present the services are not unified across all hosts having that role.