### PR TITLE
Implement foreman test environment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,204 @@
+# Testing foreman
+
+This is a rough guide for applying the code base on an existing Foreman 3.8/3.9
+installation on AlmaLinux 8.
+
+This works by introducing a nother site, called `test`. The idea is to have
+test systems that are isolated from the rest of the LSST infrastructure. For
+example IPA isn't managed and no real route53 keys are provided.
+
+## Setup the VM
+
+We use Hetzner for cloud instances to test setups:
+
+```
+hcloud server create --image=alma-8 --name=lsst.tim.betadots.training --type=cpx41 --ssh-key='bastelfreak betadots'
+hcloud server set-rdns lsst.tim.betadots.training --ip=95.217.179.41 --hostname=lsst.tim.betadots.training
+hcloud server set-rdns lsst.tim.betadots.training --ip=2a01:4f9:c012:acee::1 --hostname=lsst.tim.betadots.training
+```
+
+(Now also add matching A/AAAA records to make this easier)
+
+```
+ssh-keygen -f ~/.ssh/known_hosts -R lsst.tim.betadots.training
+ssh-keyscan lsst.tim.betadots.training >> ~/.ssh/known_hosts
+```
+
+## Patching
+
+```
+sed --in-place 's/SELINUX=permissive/SELINUX=disabled/' /etc/selinux/config
+echo 'if [ $TERM == "alacritty" ]; then export TERM=xterm-256color; fi' > /etc/profile.d/terminal.sh
+LC_ALL=en_US.UTF-8 dnf -y update
+LC_ALL=en_US.UTF-8 dnf -y install vim glibc-all-langpacks git bash-completion epel-release
+crb enable
+sync
+reboot
+```
+
+### Make vim less shitty
+
+also this provides a persistent undo history in case I derp in config files
+
+```
+mkdir -p ~/.vim/{backupdir,undodir}
+wget https://gist.githubusercontent.com/bastelfreak/a3cfa50db2a7be92c47f246f8f22ca5c/raw/dab14889680d4a8bbcb83580185ca2e5040d5947/vla.vimrc -O ~/.vimrc
+```
+
+## install Puppet + Foreman
+
+```
+dnf -y install https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
+dnf -y install https://yum.theforeman.org/releases/3.8/el8/x86_64/foreman-release.rpm
+dnf -y module enable foreman:el8
+dnf -y install foreman-installer
+foreman-installer --enable-foreman-plugin-puppetdb
+dnf -y install puppetdb puppetdb-termini postgresql-contrib
+```
+
+Output from the installer should be like this:
+
+```
+[root@lsst ~]# foreman-installer --enable-foreman-plugin-puppetdb
+2024-02-09 19:15:16 [NOTICE] [root] Loading installer configuration. This will take some time.
+2024-02-09 19:15:18 [NOTICE] [root] Running installer with log based terminal output at level NOTICE.
+2024-02-09 19:15:18 [NOTICE] [root] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
+2024-02-09 19:15:20 [NOTICE] [configure] Starting system configuration.
+2024-02-09 19:16:21 [NOTICE] [configure] 250 configuration steps out of 1244 steps complete.
+2024-02-09 19:16:32 [NOTICE] [configure] 500 configuration steps out of 1247 steps complete.
+2024-02-09 19:16:37 [NOTICE] [configure] 750 configuration steps out of 1272 steps complete.
+2024-02-09 19:16:49 [NOTICE] [configure] 1000 configuration steps out of 1272 steps complete.
+2024-02-09 19:18:04 [NOTICE] [configure] 1250 configuration steps out of 1272 steps complete.
+2024-02-09 19:18:07 [NOTICE] [configure] System configuration has finished.
+Executing: foreman-rake upgrade:run
+  Success!
+  * Foreman is running at https://lsst.tim.betadots.training
+      Initial credentials are admin / oXBKGyVfGa4wJzEQ
+  * Foreman Proxy is running at https://lsst.tim.betadots.training:8443
+
+The full log is at /var/log/foreman-installer/foreman.log
+[root@lsst ~]#
+```
+
+### Configure r10k
+
+# Install r10k + control-repo
+
+First we want to stop puppet so it doesn't make unexpected changes in the
+background after code got deployed.
+
+```
+systemctl disable --now puppet
+```
+
+Now install r10k
+
+```
+source /etc/profile.d/puppet-agent.sh
+# required if we're on Puppet 7, which contains Ruby 2.7. newer faraday wants ruby 3
+puppet resource package faraday ensure=2.8.1 provider=puppet_gem
+puppet resource package r10k ensure=installed provider=puppet_gem
+ln -s /opt/puppetlabs/puppet/bin/r10k /usr/local/bin/
+```
+
+configure r10k
+
+```
+mkdir -p /etc/puppetlabs/r10k
+cat > /etc/puppetlabs/r10k/r10k.yaml << EOF
+---
+pool_size: 8
+deploy:
+  generate_types: true
+  purge_levels:
+  - deployment
+  exclude_spec: true
+  incremental: true
+:postrun: []
+:cachedir: /opt/puppetlabs/puppet/cache/r10k
+:sources:
+  puppet:
+    basedir: /etc/puppetlabs/code/environments
+    remote: https://github.com/bastelfreak/lsst-control
+EOF
+```
+
+deploy the code
+
+```
+r10k deploy environment production bastelfreak --modules --verbose --color
+```
+
+## Configure PuppetDB
+
+Setup the database and user
+
+```
+su --login postgres --command 'createuser --no-createdb --no-createrole --no-superuser puppetdb'
+su --login postgres --command 'createuser --no-createdb --no-createrole --no-superuser puppetdb_read'
+su --login postgres --command 'createdb --encoding UTF8 --owner postgres puppetdb'
+su --login postgres --command "psql puppetdb --command 'revoke create on schema public from public'"
+su --login postgres --command "psql puppetdb --command 'grant create on schema public to puppetdb'"
+su --login postgres --command "psql puppetdb --command 'alter default privileges for user puppetdb in schema public grant select on tables to puppetdb_read'"
+su --login postgres --command "psql puppetdb --command 'alter default privileges for user puppetdb in schema public grant usage on sequences to puppetdb_read'"
+su --login postgres --command "psql puppetdb --command 'alter default privileges for user puppetdb in schema public grant execute on functions to puppetdb_read'"
+su --login postgres --command "psql puppetdb --command 'create extension pg_trgm'"
+su --login postgres --command "psql puppetdb --command \"ALTER USER puppetdb WITH PASSWORD 'PASSWORD'\""
+su --login postgres --command "psql puppetdb --command \"ALTER USER puppetdb_read WITH PASSWORD 'PASSWORD'\""
+```
+
+Tell PuppetDB to use the database
+
+```
+echo '[database]' > /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'subname = //127.0.0.1:5432/puppetdb' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'username = puppetdb' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'password = PASSWORD' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo '[read-database]' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'subname = //127.0.0.1:5432/puppetdb' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'username = puppetdb_read' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+echo 'password = PASSWORD' >> /etc/puppetlabs/puppetdb/conf.d/database.ini
+```
+
+Start PuppetDB
+
+```
+systemctl enable --now puppetdb
+```
+
+Update Puppetserver to talk to PuppetDB
+```
+puppet config set --section server storeconfigs true
+puppet config set --section main reports foreman,puppetdb
+echo -e "[main]\nserver_urls = https://$(hostname -f):8081/\nsoft_write_failure = false" > /etc/puppetlabs/puppet/puppetdb.conf
+systemctl restart puppetserver
+```
+
+## configure node in foreman
+
+We need to ensure foreman knows the environment `bastelfreak` before we can
+assign it
+
+* login at https://lsst.tim.betadots.training/
+* got to https://lsst.tim.betadots.training/foreman_puppet/environments, import new environments
+
+We need to set the environment in foreman
+
+* login at https://lsst.tim.betadots.training/
+* select the node, click edit
+    * should bring you to https://lsst.tim.betadots.training/hosts/lsst.tim.betadots.training/edit
+* At environment, select `bastelfreak`
+* save
+
+We need to set the role and site
+
+* login at https://lsst.tim.betadots.training/
+* At https://lsst.tim.betadots.training/hosts/lsst.tim.betadots.training/edit, go to `Parameters`
+* Select `Add Parameter`
+* Name=site, Value=test; save
+* Repeat: Name=role, Value=foreman; save
+
+
+
+
+puppet agent -t accounts,prometheus,chrony,yumrepo,auditd,tftp,convenience,debugutils,rsyslog,discovery,puppetserver,host,irqbalance,ssh,lldpd,sysstat

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,21 +59,21 @@ dnf -y install puppetdb puppetdb-termini postgresql-contrib
 Output from the installer should be like this:
 
 ```
-[root@lsst ~]# foreman-installer --enable-foreman-plugin-puppetdb
-2024-02-09 19:15:16 [NOTICE] [root] Loading installer configuration. This will take some time.
-2024-02-09 19:15:18 [NOTICE] [root] Running installer with log based terminal output at level NOTICE.
-2024-02-09 19:15:18 [NOTICE] [root] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
-2024-02-09 19:15:20 [NOTICE] [configure] Starting system configuration.
-2024-02-09 19:16:21 [NOTICE] [configure] 250 configuration steps out of 1244 steps complete.
-2024-02-09 19:16:32 [NOTICE] [configure] 500 configuration steps out of 1247 steps complete.
-2024-02-09 19:16:37 [NOTICE] [configure] 750 configuration steps out of 1272 steps complete.
-2024-02-09 19:16:49 [NOTICE] [configure] 1000 configuration steps out of 1272 steps complete.
-2024-02-09 19:18:04 [NOTICE] [configure] 1250 configuration steps out of 1272 steps complete.
-2024-02-09 19:18:07 [NOTICE] [configure] System configuration has finished.
+[root@lsst ~]# foreman-installer --enable-foreman-plugin-remote-execution --enable-foreman-cli-remote-execution --enable-foreman-proxy-plugin-remote-execution-script
+2024-02-11 13:36:41 [NOTICE] [root] Loading installer configuration. This will take some time.
+2024-02-11 13:36:43 [NOTICE] [root] Running installer with log based terminal output at level NOTICE.
+2024-02-11 13:36:43 [NOTICE] [root] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
+2024-02-11 13:36:44 [NOTICE] [configure] Starting system configuration.
+2024-02-11 13:37:40 [NOTICE] [configure] 250 configuration steps out of 1323 steps complete.
+2024-02-11 13:37:48 [NOTICE] [configure] 500 configuration steps out of 1326 steps complete.
+2024-02-11 13:37:59 [NOTICE] [configure] 750 configuration steps out of 1351 steps complete.
+2024-02-11 13:38:00 [NOTICE] [configure] 1000 configuration steps out of 1351 steps complete.
+2024-02-11 13:38:17 [NOTICE] [configure] 1250 configuration steps out of 1351 steps complete.
+2024-02-11 13:39:33 [NOTICE] [configure] System configuration has finished.
 Executing: foreman-rake upgrade:run
   Success!
   * Foreman is running at https://lsst.tim.betadots.training
-      Initial credentials are admin / oXBKGyVfGa4wJzEQ
+      Initial credentials are admin / fbNn4VM4NjA2n2H4
   * Foreman Proxy is running at https://lsst.tim.betadots.training:8443
 
 The full log is at /var/log/foreman-installer/foreman.log
@@ -201,4 +201,4 @@ We need to set the role and site
 
 
 
-puppet agent -t accounts,prometheus,chrony,yumrepo,auditd,tftp,convenience,debugutils,rsyslog,discovery,puppetserver,host,irqbalance,ssh,lldpd,sysstat
+puppet agent -t --tags accounts,prometheus,chrony,yumrepo,auditd,tftp,convenience,debugutils,rsyslog,discovery,puppetserver,host,irqbalance,ssh,lldpd,sysstat

--- a/Puppetfile
+++ b/Puppetfile
@@ -112,7 +112,7 @@ mod 'stm/debconf', '5.0.0'
 mod 'syseleven/restic', '2.6.1'
 mod 'theforeman/dhcp', git: 'https://github.com/lsst-it/puppet-dhcp', ref: '4d48173'  # https://github.com/theforeman/puppet-dhcp/pull/226
 mod 'theforeman/dns', '10.1.0'
-mod 'theforeman/foreman', git: 'https://github.com/lsst-it/puppet-foreman', ref: '70b70bc'  # 20.2.0 + dep updates
+mod 'theforeman/foreman', git: 'https://github.com/theforeman/puppet-foreman', ref: '24.1.0'
 mod 'theforeman/foreman_proxy', git: 'https://github.com/lsst-it/puppet-foreman_proxy', ref: '39ef803'  # https://github.com/theforeman/puppet-foreman_proxy/pull/772 https://github.com/theforeman/puppet-foreman_proxy/pull/816
 mod 'theforeman/puppet', git: 'https://github.com/lsst-it/puppet-puppet', ref: '8ef01c3'  # https://github.com/theforeman/puppet-puppet/pull/891
 mod 'theforeman/puppetserver_foreman', '2.4.0'

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -203,8 +203,9 @@ profile::core::foreman::foreman_config:
   bmc_credentials_accessible: {value: false}  # disable bmc pass in enc yaml
   default_pxe_item_global: {value: "discovery"}
   destroy_vm_on_host_delete: {value: true}
-  discovery_fact_column: {value: "ipmi_ipaddress,ipmi_macaddress"}
-  discovery_hostname: {value: "ipmi_macaddress,discovery_bootif"}
+  # on older foreman/puppet-foreman it wasn't idempotent to set this, but it works withforeman 3.8/ puppet-foreman 24.1.0
+  discovery_fact_column: {value: '["ipmi_ipaddress","ipmi_macaddress"]'}
+  discovery_hostname: {value: '["ipmi_macaddress","discovery_bootif"]'}
   entries_per_page: {value: 100}
   # remove "docker*" from default excluded_facts
   # XXX using block scalar style results in the double quotes being preceeded
@@ -215,7 +216,9 @@ profile::core::foreman::foreman_config:
   #excluded_facts:
   #  value: '["lo", "en*v*", "usb*", "vnet*", "macvtap*", ";vdsmdummy;", "veth*", "tap*", "qbr*", "qvb*", "qvo*", "qr-*", "qg-*", "vlinuxbr*", "vovsbr*", "br-int", "vif*", "load_averages::*", "memory::swap::available*", "memory::swap::capacity", "memory::swap::used*", "memory::system::available*", "memory::system::capacity", "memory::system::used*", "memoryfree", "memoryfree_mb", "swapfree", "swapfree_mb", "uptime_hours", "uptime_days"]'
   host_details_ui: {value: false}  # https://projects.theforeman.org/issues/35115
-  host_power_status: {value: false}
+  # since isn't required/doesn't work anymore since https://github.com/theforeman/foreman/pull/9462/files
+  # the option host_power_status doesn't exist in foreman 3.8, I think due to #9462, but that's a bit of a guess
+  # host_power_status: {value: false}
   idle_timeout: {value: 7200}  # session timeout in minutes
   ignore_puppet_facts_for_provisioning: {value: true}
   matchers_inheritance: {value: false}

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -81,6 +81,7 @@ foreman::oauth_active: true
 #foreman::oauth_consumer_key:  # secret
 #foreman::oauth_consumer_secret:  # secret
 foreman::passenger: false  # use puma; param removed in theforman/foreman >= 17.0.0
+# we need to figure out how to configure columns in newer foreman versions
 foreman::plugin::column_view::columns:
   role:
     title: "Role"

--- a/hieradata/site/test.yaml
+++ b/hieradata/site/test.yaml
@@ -1,13 +1,13 @@
 ---
 # some hacks to get puppet working outside of LSST
-profile::core::common::manage_ipa: false
 ipa::domain_join_password: "foofoofoofoo"
 resolv_conf::nameservers:
   - "185.12.64.2"
   - "185.12.64.1"
   - "2a01:4ff:ff00::add:2"
   - "2a01:4ff:ff00::add:1"
-profile::core::foreman::smee_url: "https://smee.io/foo"
+# profile::core::foreman::smee_url: "https://smee.io/foo"
+profile::core::foreman::manage_smee: false
 foreman_proxy::plugin::dns::route53::aws_access_key: "foo"
 foreman_proxy::plugin::dns::route53::aws_secret_key: "foo"
 puppet::server::puppetdb::server: "%{trusted.certname}"
@@ -38,4 +38,5 @@ puppetdb::globals::version: '7.16.0'
 profile::core::common::manage_sssd: false
 profile::core::common::manage_network_manager: false
 profile::core::common::manage_krb5: false
+# ipa class is still added to the catalog :thinking:
 profile::core::common::manage_ipa: false

--- a/hieradata/site/test.yaml
+++ b/hieradata/site/test.yaml
@@ -1,12 +1,9 @@
 ---
-# some hacks to get puppet working outside of LSST
-ipa::domain_join_password: "foofoofoofoo"
 resolv_conf::nameservers:
   - "185.12.64.2"
   - "185.12.64.1"
   - "2a01:4ff:ff00::add:2"
   - "2a01:4ff:ff00::add:1"
-# profile::core::foreman::smee_url: "https://smee.io/foo"
 profile::core::foreman::manage_smee: false
 foreman_proxy::plugin::dns::route53::aws_access_key: "foo"
 foreman_proxy::plugin::dns::route53::aws_secret_key: "foo"
@@ -38,5 +35,4 @@ puppetdb::globals::version: '7.16.0'
 profile::core::common::manage_sssd: false
 profile::core::common::manage_network_manager: false
 profile::core::common::manage_krb5: false
-# ipa class is still added to the catalog :thinking:
 profile::core::common::manage_ipa: false

--- a/hieradata/site/test.yaml
+++ b/hieradata/site/test.yaml
@@ -1,0 +1,41 @@
+---
+# some hacks to get puppet working outside of LSST
+profile::core::common::manage_ipa: false
+ipa::domain_join_password: "foofoofoofoo"
+resolv_conf::nameservers:
+  - "185.12.64.2"
+  - "185.12.64.1"
+  - "2a01:4ff:ff00::add:2"
+  - "2a01:4ff:ff00::add:1"
+profile::core::foreman::smee_url: "https://smee.io/foo"
+foreman_proxy::plugin::dns::route53::aws_access_key: "foo"
+foreman_proxy::plugin::dns::route53::aws_secret_key: "foo"
+puppet::server::puppetdb::server: "%{trusted.certname}"
+r10k::sources:
+  control:
+    remote: "https://github.com/bastelfreak/lsst-control"
+    basedir: "/etc/puppetlabs/code/environments"
+    invalid_branches: "correct"
+lookup_options:
+  r10k::sources:
+    merge:
+      strategy: "first"
+
+puppet::server_puppetserver_version: &server_version '7.15.0'
+puppet::server_version: '7.15.0'
+puppet_agent::package_version: '7.28.0'
+profile::core::yum::versionlock:
+  puppetdb-termini:
+    ensure: "present"
+    version: "7.16.0"
+    release: "1.el8"
+    before: "Package[puppetdb-termini]"
+
+foreman::repo::repo: "3.8"
+foreman::version: "3.8.0"
+puppetdb::globals::version: '7.16.0'
+
+profile::core::common::manage_sssd: false
+profile::core::common::manage_network_manager: false
+profile::core::common::manage_krb5: false
+profile::core::common::manage_ipa: false

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,4 +1,4 @@
-lookup('classes', Array[String], 'unique').include
+lookup('classes', Array[String], 'unique', []).include
 
 $files = lookup(
   name          => 'files',

--- a/site/profile/manifests/core/foreman.pp
+++ b/site/profile/manifests/core/foreman.pp
@@ -39,7 +39,10 @@ class profile::core::foreman (
   include foreman::compute::libvirt
   include foreman::compute::vmware
   include foreman_envsync
-  include foreman::plugin::column_view
+  # the plugin isn't supported in foreman 3.8 and newer
+  # https://github.com/theforeman/foreman_column_view
+  # it's now integrated into foreman
+  # include foreman::plugin::column_view
   include foreman::plugin::discovery
   include foreman::plugin::puppet
   include foreman::plugin::remote_execution


### PR DESCRIPTION
I added an INSTALL.md with some instructions. This doesn't pass yet. So far this works:

```
puppet agent -t accounts,prometheus,chrony,yumrepo,auditd,tftp,convenience,debugutils,rsyslog,discovery,puppetserver,host,irqbalance,ssh,lldpd,sysstat
```

Somehow something breaks the dynflow database if I apply the whole catalog and then foreman doesn't start anymore. I will investigate next week.