### PR TITLE
profile::core::common: remove redundant ipa include

### DIFF
--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -71,7 +71,6 @@ class profile::core::common (
   include profile::core::ca
   include profile::core::convenience
   include profile::core::dielibwrapdie
-  include profile::core::ipa
   include profile::core::k5login
   include profile::core::kernel
   include profile::core::keytab


### PR DESCRIPTION
We've a conditional, `$manage_ipa`. When that's true, we include `profile::core::ipa`. We probably shouldn't include the class without the conditional?