### PR TITLE
(profile::core::docker) fix docker 24.x compatibility

### DIFF
--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -14,20 +14,19 @@
 #   Array of yum::versionlock resources to create
 #
 class profile::core::docker (
-  Optional[String] $version,
-  String $socket_group                      = '70014',
-  String $storage_driver                    = 'overlay2',
-  Optional[Hash[String, Hash]] $versionlock = undef,
+  Optional[String[1]] $version,
+  String[1] $socket_group                      = '70014',
+  String[1] $storage_driver                    = 'overlay2',
+  Optional[Hash[String[1], Hash]] $versionlock = undef,
 ) {
   include docker::networks
 
   class { 'docker':
-    overlay2_override_kernel_check => true,  # needed on el7
-    package_source                 => 'docker-ce',
-    socket_group                   => $socket_group,
-    socket_override                => false,
-    storage_driver                 => $storage_driver,
-    version                        => $version,
+    package_source  => 'docker-ce',
+    socket_group    => $socket_group,
+    socket_override => false,
+    storage_driver  => $storage_driver,
+    version         => $version,
   }
 
   if $versionlock {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -608,7 +608,6 @@ shared_examples 'docker' do
 
   it do
     is_expected.to contain_class('docker').with(
-      overlay2_override_kernel_check: true,
       package_source: 'docker-ce',
       socket_group: 70_014,
       socket_override: false,


### PR DESCRIPTION
Resolves this error under docker 24.x:

    dockerd[21155]: failed to start daemon: error initializing graphdriver: overlay2: unknown option overlay2.override_kernel_check: overlay2