### PR TITLE
(comcam-dc01.tu.lsst.org) update network config to EL9

### DIFF
--- a/hieradata/node/comcam-dc01.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-dc01.tu.lsst.org.yaml
@@ -4,18 +4,20 @@ profile::daq::daq_interface::uuid: "b3cb2632-fc6f-4698-b8f5-feea068266ed"
 profile::daq::daq_interface::was: "p2p2"
 profile::daq::daq_interface::mode: "dhcp-client"
 
-network::interfaces_hash:
-  p2p1:  # fqdn
-    bootproto: "dhcp"
-    defroute: "yes"
-    onboot: "yes"
-    type: "Ethernet"
-  em1: &not_connected
-    bootproto: "none"
-    onboot: "no"
-    type: "Ethernet"
-  em2:
-    <<: *not_connected
+nm::connections:
+  ens2f0:
+    content:
+      connection:
+        id: "ens2f0"
+        uuid: "03da7500-2101-c722-2438-d0d006c28c73"
+        type: "ethernet"
+        interface-name: "ens2f0"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}
 
 nfs::client_enabled: true
 nfs::client_mounts:

--- a/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'comcam-dc01.tu.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        override_facts(os_facts,
+                       fqdn: 'comcam-dc01.tu.lsst.org',
+                       is_virtual: false,
+                       virtual: 'physical',
+                       dmi: {
+                         'product' => {
+                           'name' => 'PowerEdge R440',
+                         },
+                       })
+      end
+      let(:node_params) do
+        {
+          role: 'ccs-dc',
+          site: 'tu',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'baremetal'
+      include_context 'with nm interface'
+
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens2f0' do
+        let(:interface) { 'ens2f0' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm dhcp interface'
+        it_behaves_like 'nm ethernet interface'
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
This PR is opened to update the network configuration to EL9 for comcam-dc01.tu.lsst.org. 