### PR TITLE
(spec) fix pillan/tu spec for rke 1.4.6

### DIFF
--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
 
@@ -41,7 +42,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('profile::core::rke').with(
           enable_dhcp: true,
-          version: '1.3.12',
+          version: '1.4.6',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -62,8 +62,8 @@ describe "#{role} role" do
 
         it do
           is_expected.to contain_class('rke').with(
-            version: '1.3.12',
-            checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+            version: '1.4.6',
+            checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
           )
         end
       end # host


### PR DESCRIPTION
The production branch was broken by an accidental push that github branch protection let through with only a warning:

https://github.com/lsst-it/lsst-control/commit/60c2bfac6695f6d1009e9f4a4995d9cc848ea389