### PR TITLE
(gha) use 32core runner for "rake checks"

### DIFF
--- a/.github/workflows/rake_checks.yaml
+++ b/.github/workflows/rake_checks.yaml
@@ -17,7 +17,7 @@ jobs:
   rake_checks:
     runs-on:
       group: Default Larger Runners
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-latest-32-cores
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Reduces run time from ~8 mins -> ~5mins.