### PR TITLE
(role/ccs-mcm) move common services here from mcm nodes

### DIFF
--- a/hieradata/node/comcam-mcm.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.cp.lsst.org.yaml
@@ -38,10 +38,3 @@ network::mroutes_hash:
       "139.229.167.0/24": "139.229.170.254"
       #"139.229.170.0/24": "139.229.170.254"
       "139.229.178.0/24": "139.229.170.254"
-
-ccs_software::services:
-  prod:
-    - "comcam-mmm"
-## Next two are handled by the ccs_sal module. FIXME duplication.
-#    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
-#    - "comcam-ocs-bridge"

--- a/hieradata/node/comcam-mcm.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.cp.lsst.org.yaml
@@ -41,10 +41,7 @@ network::mroutes_hash:
 
 ccs_software::services:
   prod:
-    - "mmm"
     - "comcam-mmm"
-    - "cluster-monitor"
-    - "lockmanager"
 ## Next two are handled by the ccs_sal module. FIXME duplication.
 #    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
 #    - "comcam-ocs-bridge"

--- a/hieradata/node/comcam-mcm.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.tu.lsst.org.yaml
@@ -36,10 +36,3 @@ network::mroutes_hash:
   p1p2:
     ensure: "absent"
     routes: {}
-
-ccs_software::services:
-  prod:
-    - "comcam-mmm"
-## Next two are handled by the ccs_sal module. FIXME duplication.
-#    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
-#    - "comcam-ocs-bridge"

--- a/hieradata/node/comcam-mcm.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.tu.lsst.org.yaml
@@ -39,10 +39,7 @@ network::mroutes_hash:
 
 ccs_software::services:
   prod:
-    - "mmm"
     - "comcam-mmm"
-    - "cluster-monitor"
-    - "lockmanager"
 ## Next two are handled by the ccs_sal module. FIXME duplication.
 #    - "comcam-mcm"  # XXX should both comcam-mcm and mcm-comcam be running???
 #    - "comcam-ocs-bridge"

--- a/hieradata/node/lsstcam-mcm.ls.lsst.org.yaml
+++ b/hieradata/node/lsstcam-mcm.ls.lsst.org.yaml
@@ -1,8 +1,0 @@
----
-ccs_software::services:
-  prod:
-## Next two are handled by the ccs_sal module.
-#    - "mcm"
-#    - "ocs-bridge"
-    - "cluster-monitor"
-    - "lockmanager"

--- a/hieradata/role/ccs-mcm.yaml
+++ b/hieradata/role/ccs-mcm.yaml
@@ -20,3 +20,9 @@ profile::ccs::tomcat::wars:
 profile::core::systemd::tmpfile:
   docker_tmp.conf:  # XXX short term kludge
     content: "x /tmp/docker_tmp 0777 saluser saluser -"
+
+ccs_software::services:
+  prod:
+    - "mmm"
+    - "cluster-monitor"
+    - "lockmanager"


### PR DESCRIPTION
This moves mmm, cluster-monitor, lockmanager to the role. On lsstcam-mcm.ls, it adds mmm (previously missing). On lsstcam-mcm.cp, it adds all three (previously missing).

Affects nodes:
comcam-mcm.{cp,tu}
lsstcam-mcm.{cp,ls}