### PR TITLE
(site/ls) bump docker to 24.0.9

### DIFF
--- a/hieradata/site/ls.yaml
+++ b/hieradata/site/ls.yaml
@@ -55,3 +55,5 @@ profile::core::firewall::firewall:
     ipset: "ayekan src"
     dport: "9100"
     action: "accept"
+
+profile::core::docker::version: "24.0.9"

--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,3 +1,2 @@
 ---
-profile::core::docker::version: "24.0.9"
 profile::core::rke::version: "1.4.6"


### PR DESCRIPTION
All ls rke nodes have already been upgraded to 24.0.9.  At least these non-rke hosts have docker as part of their role:

-  azar01.ls.lsst.org 
-  foreman.ls.lsst.org 
-  love01.ls.lsst.org 
-  tel-hw1.ls.lsst.org 