### PR TITLE
(site/cp) bump docker to 24.0.9

### DIFF
--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -50,3 +50,4 @@ accounts::user_list:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN16b56V3j7wot509IlRvOFXaLxI9AH9/eOr1WuLEdpGoQ3lDuz26P6zFLbopjgsZxdzxE492QAmGpdUkn+Ducny1JK83L0N/d6INrM48fQeiUiSsN/YKua9qO8QQbvTsiiKanj38u9x1vOfqKn2/kK7BKAZblr+qT7U6nofMFlG3zJpNOCAIHyd4DJRrWB+xPR1YRwljV6BOtpI5+/FwdoX+/61cdsP0895iejDlnYRNFBYWRdGHDdDN6yfSNy00D/ADwaZP9sO+gyvHPqz/saPFYx8Petbhl/PlUjqWx7sktQxPgpMPBU/KQU5SEd5RkcT+CVjLHuHfOa3jXEdVx foreman-proxy@foreman.cp.lsst.org"
 
 profile::core::common::disable_ipv6: true
+profile::core::docker::version: "24.0.9"

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -28,6 +28,7 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
 

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
 

--- a/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
@@ -28,6 +28,8 @@ describe 'rancher01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
+
       it do
         is_expected.to contain_class('profile::core::rke').with(
           version: '1.4.6',

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -30,6 +30,7 @@ describe 'yagan01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
 

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
+      include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
 


### PR DESCRIPTION
Note that some tu hosts are still on docker 23.x and will need to be upgraded before the default docker version may be changed to 24.x.