### PR TITLE
(node/comcam-mcm.tu.lsst.org) rm ignore-auto-dns from manual interface

### DIFF
--- a/hieradata/node/comcam-mcm.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.tu.lsst.org.yaml
@@ -36,7 +36,6 @@ nm::connections:
         stp: false
       ipv4:
         address1: "140.252.147.52/28"
-        ignore-auto-dns: true
         method: "manual"
       ipv6:
         method: "disabled"

--- a/spec/hosts/nodes/comcam-mcm.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-mcm.tu.lsst.org_spec.rb
@@ -54,7 +54,6 @@ describe 'comcam-mcm.tu.lsst.org', :sitepp do
         it_behaves_like 'nm bridge interface'
         it_behaves_like 'nm manual interface'
         it { expect(nm_keyfile['ipv4']['address1']).to eq('140.252.147.52/28') }
-        it { expect(nm_keyfile['ipv4']['ignore-auto-dns']).to be true }
       end
     end # on os
   end # on_supported_os


### PR DESCRIPTION
This configuration directive has no effect unless the interface is using dhcp.