### PR TITLE
(node/comcam-dc01.tu.lsst.org) fix ens2f1 interface uuid

### DIFF
--- a/hieradata/node/comcam-dc01.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-dc01.tu.lsst.org.yaml
@@ -17,7 +17,7 @@ nm::connections:
     content:
       connection:
         id: "ens2f1"
-        uuid: "1aea73f67-58f6-4119-abd6-d9d72235297b"
+        uuid: "92e489fd-9f97-4d04-88ee-7b1cf65427c9"
         type: "ethernet"
         interface-name: "ens2f1"
         master: "lsst-daq"


### PR DESCRIPTION
Resolves this error:

    Mar 11 21:44:02 comcam-dc01.tu.lsst.org NetworkManager[1407]: <warn>  [1710193442.2488] keyfile: load: "/etc/NetworkManager/system-connections/ens2f1.nmconnection": failed to load connection: invalid connection: connection.uuid: '1aea73f67-58f6-4119-abd6-d9d72235297b' is not a valid UUID