### PR TITLE
(role/comcam-fp) move ccs services here from the node level

### DIFF
--- a/hieradata/node/comcam-fp01.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-fp01.cp.lsst.org.yaml
@@ -63,11 +63,9 @@ ccs_monit::ping_hosts:
   - "comcam-lion03"
   - "pathfinder-lion01"
 
-ccs_software::services:
-  prod:
-    - "comcam-daq-monitor"
-    - "comcam-fp"
-    - {name: "comcam-ih", user: "ccs-ipa", group: "ccs-ipa", workdir: "/home/ccs-ipa", env: "PATH=/usr/lib/jvm/zulu-17/bin:/usr/sbin:/usr/bin"}
+# See also role/comcam-fp.
+# ccs_software::services:
+#   prod:
     # XXX
     # - "cantaloupe"
     # - "dsid"

--- a/hieradata/node/comcam-fp01.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-fp01.tu.lsst.org.yaml
@@ -63,6 +63,4 @@ nfs::client_mounts:
 
 ccs_software::services:
   prod:
-    - "comcam-fp"
-    - {name: "comcam-ih", user: "ccs-ipa", group: "ccs-ipa", workdir: "/home/ccs-ipa", env: "PATH=/usr/lib/jvm/zulu-17/bin:/usr/sbin:/usr/bin"}
     - "h2db"

--- a/hieradata/role/comcam-fp.yaml
+++ b/hieradata/role/comcam-fp.yaml
@@ -10,3 +10,9 @@ classes:
   - "profile::core::nfsserver"
 
 profile::ccs::file_transfer::install: true
+
+ccs_software::services:
+  prod:
+    - "comcam-daq-monitor"
+    - "comcam-fp"
+    - {name: "comcam-ih", user: "ccs-ipa", group: "ccs-ipa", workdir: "/home/ccs-ipa", env: "PATH=/usr/lib/jvm/zulu-17/bin:/usr/sbin:/usr/bin"}

--- a/spec/hosts/nodes/comcam-fp01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-fp01.tu.lsst.org_spec.rb
@@ -22,6 +22,7 @@ describe 'comcam-fp01.tu.lsst.org', :sitepp do
         {
           role: 'comcam-fp',
           site: 'tu',
+          cluster: 'comcam-ccs',
         }
       end
 
@@ -56,6 +57,11 @@ describe 'comcam-fp01.tu.lsst.org', :sitepp do
         it_behaves_like 'nm bridge interface'
         it { expect(nm_keyfile['ipv4']['ignore-auto-dns']).to be true }
       end
+
+      it { is_expected.to contain_service('comcam-daq-monitor') }
+      it { is_expected.to contain_service('comcam-fp') }
+      it { is_expected.to contain_service('comcam-ih') }
+      it { is_expected.to contain_service('h2db') }
     end # on os
   end # on_supported_os
 end


### PR DESCRIPTION
The net result is to add the service comcam-daq-monitor on comcam-fp01.tu.