### PR TITLE
(site/dev) send syslog to opensearch.ayekan.dev.lsst.org

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -39,6 +39,12 @@ lookup_options:
   ipset::sets:
     merge:
       strategy: "deep"
+  rsyslog::feature_packages:
+    merge:
+      strategy: "deep"
+  rsyslog::config::modules:
+    merge:
+      strategy: "deep"
   rsyslog::config::actions:
     merge:
       strategy: "deep"
@@ -265,6 +271,8 @@ puppet_agent::config:
   - {section: "agent", setting: "environment", ensure: "absent"}
 
 # Rsyslog configuration is based on the default rsyslog.conf shipping with CentOS 7.7
+rsyslog::conf_permissions: "0640"  # conf file may contain secrets
+rsyslog::confdir_permissions: "0750"
 rsyslog::config::global_config:
   workDirectory:
     value: "/var/lib/rsyslog"

--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -1,5 +1,9 @@
 ---
 ipa::ipa_master_fqdn: "ipa1.ls.lsst.org"
+rsyslog::feature_packages:
+  - "rsyslog-elasticsearch"
+rsyslog::config::modules:
+  omelasticsearch: {}
 rsyslog::config::actions:
   graylogls:
     type: "omfwd"
@@ -8,6 +12,20 @@ rsyslog::config::actions:
       Target: "collector.ls.lsst.org"
       Port: 5514
       Protocol: "udp"
+  opensearch:
+    type: "omelasticsearch"
+    facility: "*.*"
+    config:
+      server: "opensearch.ayekan.dev.lsst.org"
+      serverport: 443
+      allowunsignedcerts: "on"  # off for prod
+      searchIndex: "rsyslog-hosts"
+      bulkmode: "on"
+      maxbytes: "100m"
+      queue.type: "linkedlist"
+      queue.size: "5000"
+      queue.dequeuebatchsize: "300"
+      action.resumeretrycount: "-1"
 # The following keys are shared between the `dhcp` and `resolv_conf` classes:
 # - dhcp::dnsdomain
 # - dhcp::nameservers

--- a/spec/hosts/roles/allsky_cam_spec.rb
+++ b/spec/hosts/roles/allsky_cam_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           it { is_expected.to contain_package('libgphoto2') }
         end # host
       end # lsst_sites

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -25,7 +25,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
           include_examples 'dco'
 

--- a/spec/hosts/roles/atsccs_spec.rb
+++ b/spec/hosts/roles/atsccs_spec.rb
@@ -25,7 +25,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           it { is_expected.to contain_class('ccs_sal') }
         end # host

--- a/spec/hosts/roles/atsdaq_spec.rb
+++ b/spec/hosts/roles/atsdaq_spec.rb
@@ -25,7 +25,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'lsst-daq sysctls'
           # it { is_expected.to contain_class('ccs_daq') }

--- a/spec/hosts/roles/atshcu_spec.rb
+++ b/spec/hosts/roles/atshcu_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
           include_examples 'gpio', os_facts: os_facts

--- a/spec/hosts/roles/auxtel_archiver_spec.rb
+++ b/spec/hosts/roles/auxtel_archiver_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'lhn sysctls'
           include_examples 'archiver'
           include_examples 'docker'

--- a/spec/hosts/roles/auxtel_vent_gate_spec.rb
+++ b/spec/hosts/roles/auxtel_vent_gate_spec.rb
@@ -35,7 +35,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
           include_examples 'gpio', os_facts: os_facts
           include_examples 'i2c', os_facts: os_facts

--- a/spec/hosts/roles/bastion_spec.rb
+++ b/spec/hosts/roles/bastion_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }
 

--- a/spec/hosts/roles/catchall_spec.rb
+++ b/spec/hosts/roles/catchall_spec.rb
@@ -36,7 +36,7 @@ roles_without_spec.each do |role|
 
             it { is_expected.to compile.with_all_deps }
 
-            include_examples 'common', os_facts: os_facts
+            include_examples 'common', os_facts: os_facts, site: site
           end # host
         end # site
       end # on os

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -25,7 +25,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
           include_examples 'lsst-daq sysctls', os_facts: os_facts

--- a/spec/hosts/roles/ccs_desktop_spec.rb
+++ b/spec/hosts/roles/ccs_desktop_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
         end # host

--- a/spec/hosts/roles/ccs_hcu_spec.rb
+++ b/spec/hosts/roles/ccs_hcu_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('ccs_hcu') }

--- a/spec/hosts/roles/ccs_mcm_spec.rb
+++ b/spec/hosts/roles/ccs_mcm_spec.rb
@@ -30,7 +30,7 @@ describe "#{role} role" do
 
               it { is_expected.to compile.with_all_deps }
 
-              include_examples 'common', os_facts: os_facts
+              include_examples 'common', os_facts: os_facts, site: site
               include_examples 'ccs common', os_facts: os_facts
               include_examples 'x2go packages', os_facts: os_facts
             end # host

--- a/spec/hosts/roles/ccs_viswork_spec.rb
+++ b/spec/hosts/roles/ccs_viswork_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'x2go packages', os_facts: os_facts
         end # host

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'lhn sysctls'
           include_examples 'archiver'
           include_examples 'docker'

--- a/spec/hosts/roles/comcam_fp_spec.rb
+++ b/spec/hosts/roles/comcam_fp_spec.rb
@@ -25,7 +25,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           include_examples 'lsst-daq sysctls'
           it { is_expected.not_to contain_class('profile::core::sysctl::lhn') }

--- a/spec/hosts/roles/daq_mgt_spec.rb
+++ b/spec/hosts/roles/daq_mgt_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-shared_examples 'generic daq manager' do |os_facts:|
-  include_examples 'common', os_facts: os_facts, chrony: false
+shared_examples 'generic daq manager' do |os_facts:, site:|
+  include_examples 'common', os_facts: os_facts, site: site, chrony: false
   include_examples 'lsst-daq sysctls'
   include_examples 'nfsv2 enabled', os_facts: os_facts
   include_examples 'daq common'
@@ -68,7 +68,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'generic daq manager', os_facts: os_facts
+          include_examples 'generic daq manager', os_facts: os_facts, site: site
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/dco_spec.rb
+++ b/spec/hosts/roles/dco_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
           include_examples 'dco'
 

--- a/spec/hosts/roles/dimm_spec.rb
+++ b/spec/hosts/roles/dimm_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           it { is_expected.to contain_class('profile::core::yum::lsst_ts_private') }
           it { is_expected.to contain_package('ts_dimm_app-2.0-1.el8.x86_64') }
           it { is_expected.to contain_package('telnet') }

--- a/spec/hosts/roles/dm_bastion_spec.rb
+++ b/spec/hosts/roles/dm_bastion_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           it { is_expected.to have_nfs__client__mount_resource_count(6) }
 
           it do

--- a/spec/hosts/roles/dnscache_spec.rb
+++ b/spec/hosts/roles/dnscache_spec.rb
@@ -26,7 +26,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
 
           it do
             is_expected.to contain_class('dns').with(

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
 
           it { is_expected.to contain_package('docker-compose-plugin') }

--- a/spec/hosts/roles/dtn_spec.rb
+++ b/spec/hosts/roles/dtn_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           it { is_expected.to contain_class('profile::core::common') }
           it { is_expected.to contain_class('profile::core::dtn') }
 

--- a/spec/hosts/roles/ess_spec.rb
+++ b/spec/hosts/roles/ess_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ftdi'
           include_examples 'rubinhat'
         end # host

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -20,7 +20,8 @@ describe "#{role} role" do
 
       describe 'foreman.dev.lsst.org', :sitepp do
         os_facts.merge!(fqdn: 'foreman.dev.lsst.org')
-        let(:site) { 'dev' }
+        site = 'dev'
+        let(:site) { site }
         let(:ntpservers) do
           %w[
             ntp.shoa.cl
@@ -44,13 +45,14 @@ describe "#{role} role" do
 
         it { is_expected.to compile.with_all_deps }
 
-        include_examples 'common', os_facts: os_facts
+        include_examples 'common', os_facts: os_facts, site: site
         include_examples 'generic foreman'
       end # host
 
       describe 'foreman.tuc.lsst.cloud', :sitepp do
         os_facts.merge!(fqdn: 'foreman.tuc.lsst.cloud')
-        let(:site) { 'tu' }
+        site = 'tu'
+        let(:site) { site }
         let(:ntpservers) do
           %w[
             140.252.1.140
@@ -73,13 +75,14 @@ describe "#{role} role" do
 
         it { is_expected.to compile.with_all_deps }
 
-        include_examples 'common', os_facts: os_facts
+        include_examples 'common', os_facts: os_facts, site: site
         include_examples 'generic foreman'
       end # host
 
       describe 'foreman.ls.lsst.org', :sitepp do
         os_facts.merge!(fqdn: 'foreman.ls.lsst.org')
-        let(:site) { 'ls' }
+        site = 'ls'
+        let(:site) { site }
         let(:ntpservers) do
           %w[
             ntp.shoa.cl
@@ -103,13 +106,14 @@ describe "#{role} role" do
 
         it { is_expected.to compile.with_all_deps }
 
-        include_examples 'common', os_facts: os_facts
+        include_examples 'common', os_facts: os_facts, site: site
         include_examples 'generic foreman'
       end # host
 
       describe 'foreman.cp.lsst.org', :sitepp do
         os_facts.merge!(fqdn: 'foreman.cp.lsst.org')
-        let(:site) { 'cp' }
+        site = 'cp'
+        let(:site) { site }
         let(:ntpservers) do
           %w[
             ntp.cp.lsst.org
@@ -132,7 +136,7 @@ describe "#{role} role" do
 
         it { is_expected.to compile.with_all_deps }
 
-        include_examples 'common', os_facts: os_facts
+        include_examples 'common', os_facts: os_facts, site: site
         include_examples 'generic foreman'
       end # host
     end

--- a/spec/hosts/roles/generic_spec.rb
+++ b/spec/hosts/roles/generic_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }
 

--- a/spec/hosts/roles/hvac_spec.rb
+++ b/spec/hosts/roles/hvac_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }
         end # host

--- a/spec/hosts/roles/hypervisor_spec.rb
+++ b/spec/hosts/roles/hypervisor_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
 
           %w[
             libguestfs

--- a/spec/hosts/roles/ipareplica_spec.rb
+++ b/spec/hosts/roles/ipareplica_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts, no_auth: true
+          include_examples 'common', os_facts: os_facts, site: site, no_auth: true
 
           it do
             is_expected.to contain_class('tailscale').with_up_options(

--- a/spec/hosts/roles/it_ansible_spec.rb
+++ b/spec/hosts/roles/it_ansible_spec.rb
@@ -30,7 +30,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/laserrpi_spec.rb
+++ b/spec/hosts/roles/laserrpi_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
           include_examples 'gpio', os_facts: os_facts
           include_examples 'pigpio'

--- a/spec/hosts/roles/logictimer_spec.rb
+++ b/spec/hosts/roles/logictimer_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'docker'
           include_examples 'gpio', os_facts: os_facts
           include_examples 'gpshat'

--- a/spec/hosts/roles/m1m3_spec.rb
+++ b/spec/hosts/roles/m1m3_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }
 

--- a/spec/hosts/roles/m2_spec.rb
+++ b/spec/hosts/roles/m2_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }
           it { is_expected.to contain_class('profile::core::common') }

--- a/spec/hosts/roles/nfsserver_spec.rb
+++ b/spec/hosts/roles/nfsserver_spec.rb
@@ -16,12 +16,13 @@ describe "#{role} role" do
       end
 
       describe 'nfsserver.cp.lsst.org', :sitepp do
-        let(:site) { 'cp' }
+        site = 'cp'
+        let(:site) { site }
         let(:facts) { override_facts(os_facts, fqdn: 'nfsserver.cp.lsst.org') }
 
         it { is_expected.to compile.with_all_deps }
 
-        include_examples 'common', os_facts: os_facts
+        include_examples 'common', os_facts: os_facts, site: site
 
         it do
           is_expected.to contain_class('nfs').with(

--- a/spec/hosts/roles/perfsonar_spec.rb
+++ b/spec/hosts/roles/perfsonar_spec.rb
@@ -27,7 +27,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'generic perfsonar', os_facts: os_facts
           include_examples 'ipset'
           include_examples 'firewall default', os_facts: os_facts

--- a/spec/hosts/roles/puppetdb_spec.rb
+++ b/spec/hosts/roles/puppetdb_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'puppetdb'
         end # host
       end # lsst_sites

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-shared_examples 'generic rke' do |os_facts:|
-  include_examples 'common', os_facts: os_facts, node_exporter: false
+shared_examples 'generic rke' do |os_facts:, site:|
+  include_examples 'common', os_facts: os_facts, site: site, node_exporter: false
   include_examples 'debugutils'
   include_examples 'docker'
   include_examples 'rke profile'
@@ -56,53 +56,18 @@ describe "#{role} role" do
         }
       end
 
-      fqdn = "#{role}.tu.lsst.org"
-      # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      describe fqdn, :sitepp do
-        # rubocop:enable RSpec/RepeatedExampleGroupDescription
-        override_facts(os_facts, fqdn: fqdn, networking: { fqdn => fqdn })
-        let(:site) { 'tu' }
+      lsst_sites.each do |site|
+        fqdn = "#{role}.#{site}.lsst.org"
+        describe fqdn, :sitepp do
+          let(:site) { site }
 
-        it { is_expected.to compile.with_all_deps }
+          override_facts(os_facts, fqdn: fqdn, networking: { fqdn => fqdn })
 
-        include_examples 'generic rke', os_facts: os_facts
-      end # host
+          it { is_expected.to compile.with_all_deps }
 
-      fqdn = "#{role}.ls.lsst.org"
-      # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      describe fqdn, :sitepp do
-        # rubocop:enable RSpec/RepeatedExampleGroupDescription
-        override_facts(os_facts, fqdn: fqdn, networking: { fqdn => fqdn })
-        let(:site) { 'ls' }
-
-        it { is_expected.to compile.with_all_deps }
-
-        include_examples 'generic rke', os_facts: os_facts
-      end # host
-
-      fqdn = "#{role}.cp.lsst.org"
-      # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      describe fqdn, :sitepp do
-        # rubocop:enable RSpec/RepeatedExampleGroupDescription
-        override_facts(os_facts, fqdn: fqdn, networking: { fqdn => fqdn })
-        let(:site) { 'cp' }
-
-        it { is_expected.to compile.with_all_deps }
-
-        include_examples 'generic rke', os_facts: os_facts
-      end # host
-
-      fqdn = "#{role}.dev.lsst.org"
-      # rubocop:disable RSpec/RepeatedExampleGroupDescription
-      describe fqdn, :sitepp do
-        # rubocop:enable RSpec/RepeatedExampleGroupDescription
-        override_facts(os_facts, fqdn: fqdn, networking: { fqdn => fqdn })
-        let(:site) { 'dev' }
-
-        it { is_expected.to compile.with_all_deps }
-
-        include_examples 'generic rke', os_facts: os_facts
-      end # host
+          include_examples 'generic rke', os_facts: os_facts, site: site
+        end # host
+      end # lsst_sites
     end # on os
   end # on_supported_os
 end # role

--- a/spec/hosts/roles/sal_dx_spec.rb
+++ b/spec/hosts/roles/sal_dx_spec.rb
@@ -24,7 +24,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'debugutils'
           include_examples 'x2go packages', os_facts: os_facts
           it { is_expected.to contain_class('mate') }

--- a/spec/hosts/roles/tang_spec.rb
+++ b/spec/hosts/roles/tang_spec.rb
@@ -26,7 +26,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'common', os_facts: os_facts
+          include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ipset'
           include_examples 'firewall default', os_facts: os_facts
           include_examples 'firewall node_exporter scraping', site: site

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,11 +148,11 @@ end
 
 # XXX The network param is a kludge until the el8 dnscache nodes are converted
 # to NM.
-shared_examples 'common' do |os_facts:, no_auth: false, chrony: true, network: true, node_exporter: true|
+shared_examples 'common' do |os_facts:, site:, no_auth: false, chrony: true, network: true, node_exporter: true|
   include_examples 'bash_completion', os_facts: os_facts
   include_examples 'convenience'
   include_examples 'telegraf'
-  include_examples 'rsyslog defaults'
+  include_examples 'rsyslog defaults', site: site
 
   unless no_auth
     # inspect config fragment instead of class params to ensure that %{uid} is not


### PR DESCRIPTION
Note that the concat resource used by `puppet/rsyslog` to template the rsyslog config file will leak secrets into the agent logs.  The `puppet/rsyslog` module needs a param added to allow diffs to be disabled.

Related to https://github.com/lsst-it/lsst-puppet-hiera-private/pull/109