### PR TITLE
(profile::ccs::file_transfer) add option to install s3daemon

### DIFF
--- a/hieradata/role/atsdaq.yaml
+++ b/hieradata/role/atsdaq.yaml
@@ -3,9 +3,8 @@
 classes:
   - "ccs_daq"
   - "profile::ccs::common"
+  - "profile::ccs::file_transfer"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
-
-profile::ccs::file_transfer::install: true

--- a/hieradata/role/ccs-dc.yaml
+++ b/hieradata/role/ccs-dc.yaml
@@ -2,9 +2,8 @@
 classes:
   - "ccs_daq"
   - "profile::ccs::common"
+  - "profile::ccs::file_transfer"
   - "profile::ccs::graphical"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
-
-profile::ccs::file_transfer::install: true

--- a/hieradata/role/comcam-fp.yaml
+++ b/hieradata/role/comcam-fp.yaml
@@ -3,13 +3,12 @@ classes:
   - "ccs_daq"
   - "dhcp::disable"
   - "profile::ccs::common"
+  - "profile::ccs::file_transfer"
   - "profile::ccs::graphical"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::nfsclient"
   - "profile::core::nfsserver"
-
-profile::ccs::file_transfer::install: true
 
 ccs_software::services:
   prod:

--- a/site/profile/manifests/ccs/common.pp
+++ b/site/profile/manifests/ccs/common.pp
@@ -21,7 +21,6 @@ class profile::ccs::common (
 ) {
   include clustershell
   include profile::ccs::cfs
-  include profile::ccs::file_transfer
   include profile::ccs::home
   include profile::ccs::monitoring
   include profile::ccs::postfix

--- a/site/profile/manifests/ccs/file_transfer.pp
+++ b/site/profile/manifests/ccs/file_transfer.pp
@@ -23,8 +23,32 @@
 #   String specifying username for pkgurl
 # @param pkgurl_pass
 #   String specifying password for pkgurl
+# @param s3daemon
+#   Boolean, true to install s3daemon
+# @param s3daemon_repo_url
+#   URL of the s3daemon repo
+# @param s3daemon_repo_rev
+#   Git repository revision of s3daemon to install
+# @param s3daemon_repo_directory
+#   String specifying s3daemon installation directory
+# @param s3daemon_env_file
+#   String specifying s3daemon environment file
+# @param s3daemon_env_url
+#   String giving s3daemon endpoint URL
+# @param s3daemon_env_access
+#   String giving s3daemon access key
+# @param s3daemon_env_secret
+#  String giving s3daemon secret key
 #
 class profile::ccs::file_transfer (
+  String[1] $s3daemon_env_access,
+  String[1] $s3daemon_env_secret,
+  Boolean $s3daemon = false,
+  Stdlib::HTTPUrl $s3daemon_repo_url = 'https://github.com/lsst-dm/s3daemon',
+  Optional[String[1]] $s3daemon_repo_rev = undef,
+  String $s3daemon_repo_directory = '/home/ccs-ipa/s3daemon/git',
+  String $s3daemon_env_file = '/home/ccs-ipa/s3daemon/env',
+  String $s3daemon_env_url = 'https://s3dfrgw.slac.stanford.edu',
   String $directory = '/home/ccs-ipa/bin',
   String $user  = 'ccs-ipa',
   String $group = 'ccs-ipa',
@@ -37,6 +61,124 @@ class profile::ccs::file_transfer (
   String $pkgurl_user = $profile::ccs::common::pkgurl_user,
   String $pkgurl_pass = $profile::ccs::common::pkgurl_pass,
 ) {
+  ## We expect that s3daemon will become the default (and only) method
+  ## some time soonish.
+  if $s3daemon {
+    case fact('os.release.major') {
+      '7': {
+        $pip_extra_packages = [
+          'aiosignal',
+          'async-timeout',
+          'attrs',
+          'charset-normalizer',
+          'multidict',
+          'typing_extensions',
+          'yarl',
+        ]
+        $yum_extra_packages = []
+      }
+      '8': {
+        $pip_extra_packages = [
+          'aiosignal',
+        ]
+        $yum_extra_packages = [
+          'python3-async-timeout',
+          'python3-attrs',
+          'python3-charset-normalizer',
+          'python3-multidict',
+          'python3-typing-extensions',
+          'python3-yarl',
+        ]
+      }
+      default: {
+        $pip_extra_packages = []
+        $yum_extra_packages = [
+          'python3-aiosignal',
+          'python3-async-timeout',
+          'python3-attrs',
+          'python3-charset-normalizer',
+          'python3-multidict',
+          'python3-typing-extensions',
+          'python3-yarl',
+        ]
+      }
+    }
+
+    $yum_packages = $yum_extra_packages + [
+      'python3',
+      'python3-pip',
+      'python3-devel',
+    ]
+
+    $pip_packages = $pip_extra_packages + [
+      'idna_ssl',
+      'aiobotocore',
+    ]
+
+    package { $yum_packages:
+      ensure => 'present',
+    }
+
+    package { $pip_packages:
+      ensure   => 'present',
+      provider => 'pip3',
+    }
+
+    $repo_parent = "${dirname($s3daemon_repo_directory)}"
+    $env_parent = "${dirname($s3daemon_env_file)}"
+
+    $parents = [$repo_parent, $env_parent]
+
+    $parents.unique.each | String $direc | {
+      file { $direc:
+        ensure => directory,
+        mode   => '0755',
+        owner  => $user,
+        group  => $group,
+      }
+    }
+
+    $envfile_epp_vars = {
+      url    => $s3daemon_env_url,
+      access => $s3daemon_env_access,
+      secret => $s3daemon_env_secret,
+    }
+
+    file { $s3daemon_env_file:
+      content => epp("${module_name}/ccs/file_transfer/s3daemon_envfile.epp", $envfile_epp_vars),
+      owner   => $user,
+      group   => $group,
+      mode    => '0600',
+      require => File[$env_parent],
+    }
+
+    vcsrepo { $s3daemon_repo_directory:
+      ensure   => latest,
+      provider => git,
+      source   => $s3daemon_repo_url,
+      revision => $s3daemon_repo_rev,
+      user     => $user,
+      require  => File[$repo_parent],
+    }
+
+    $epp_vars = {
+      desc    => 's3daemon file transfer service',
+      user    => $user,
+      group   => $group,
+      cmd     => "/usr/bin/python3 ${s3daemon_repo_directory}/python/s3daemon/s3daemon.py",
+      workdir => "/home/${user}",
+      envfile => $s3daemon_env_file,
+    }
+
+    systemd::unit_file { 's3daemon.service':
+      content => epp("${module_name}/ccs/service.epp", $epp_vars),
+    }
+    ~> service { 's3daemon':
+      ensure => 'running',
+      enable => true,
+    }
+  }                           # s3daemon
+
   file { $directory:
     ensure => directory,
     owner  => $user,

--- a/site/profile/templates/ccs/file_transfer/s3daemon_envfile.epp
+++ b/site/profile/templates/ccs/file_transfer/s3daemon_envfile.epp
@@ -1,0 +1,7 @@
+<%- | String $url,
+      String $access,
+      String $secret
+| -%>
+S3_ENDPOINT_URL=<%= $url %>
+AWS_ACCESS_KEY_ID=<%= $access %>
+AWS_SECRET_ACCESS_KEY=<%= $secret %>

--- a/site/profile/templates/ccs/service.epp
+++ b/site/profile/templates/ccs/service.epp
@@ -1,0 +1,29 @@
+<%- | String $desc,
+      String $user,
+      String $group,
+      String $cmd,
+      String $workdir,
+      Optional[String] $envfile = undef
+| -%>
+[Unit]
+Description=<%= $desc %>
+Wants=network-online.target
+After=network-online.target
+OnFailure=status-email-user@%n.service
+
+[Service]
+Type=simple
+WorkingDirectory=<%= $workdir %>
+<% unless $envfile =~ Undef { -%>
+EnvironmentFile=<%= $envfile %>
+<% } -%>
+ExecStart=<%= $cmd %>
+Restart=on-failure
+RestartSec=42s
+StartLimitInterval=600
+StartLimitBurst=5
+User=<%= $user %>
+Group=<%= $group %>
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/classes/ccs/file_transfer_spec.rb
+++ b/spec/classes/ccs/file_transfer_spec.rb
@@ -7,12 +7,13 @@ describe 'profile::ccs::file_transfer' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with params' do
+      context 'with s3daemon' do
         let(:params) do
           {
             pkgurl: 'https://example.org',
             pkgurl_user: 'user',
             pkgurl_pass: 'pass',
+            s3daemon: true,
           }
         end
 
@@ -31,6 +32,17 @@ describe 'profile::ccs::file_transfer' do
         it { is_expected.to contain_file('/home/ccs-ipa/bin/mc').with_mode('0755') }
 
         it { is_expected.to contain_vcsrepo('/home/ccs-ipa/file-transfer') }
+
+        ## s3daemon
+        it { is_expected.to contain_vcsrepo('/home/ccs-ipa/s3daemon/git') }
+        it { is_expected.to contain_file('/home/ccs-ipa/s3daemon/env').with_mode('0600') }
+
+        it do
+          is_expected.to contain_service('s3daemon').with(
+            ensure: 'running',
+            enable: true,
+          )
+        end
       end
     end
   end

--- a/spec/classes/ccs/file_transfer_spec.rb
+++ b/spec/classes/ccs/file_transfer_spec.rb
@@ -7,10 +7,9 @@ describe 'profile::ccs::file_transfer' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with param install => true' do
+      context 'with params' do
         let(:params) do
           {
-            install: true,
             pkgurl: 'https://example.org',
             pkgurl_user: 'user',
             pkgurl_pass: 'pass',

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -11,6 +11,8 @@ ipa::directory_services_password: "foofoofoofoo"  # ipa master only
 ipa::domain_join_password: "foofoofoofoo"  # 8 char min
 foreman_proxy::plugin::dns::route53::aws_access_key: "foo"
 foreman_proxy::plugin::dns::route53::aws_secret_key: "foo"
+profile::ccs::file_transfer::s3daemon_env_access: "foo"
+profile::ccs::file_transfer::s3daemon_env_secret: "foo"
 profile::ccs::postfix::auth: "foo"
 profile::core::monitoring::database: "foo"
 profile::core::monitoring::password: "foo"


### PR DESCRIPTION
New class parameters:
(s3daemon) boolean, true to install
(s3daemon_repo_url, s3daemon_repo_rev, s3daemon_repo_directory)
  strings for repo URL and revision, and install location
(s3daemon_env_file, s3daemon_env_url, s3daemon_env_access, s3daemon_env_secret)
  strings for environment file location, and contents

When true: install required yum and pip packages; clone repository; configure and start s3daemon system service.

(templates/ccs/service.epp) new file
(templates/ccs/file_transfer/s3daemon_envfile.epp) new file