### PR TITLE
(profile::core::node_info) fwv

### DIFF
--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -75,6 +75,7 @@ class profile::core::common (
   include profile::core::kernel
   include profile::core::keytab
   include profile::core::nm_dispatch
+  include profile::core::node_info
   include profile::core::selinux
   include profile::core::systemd
   include rsyslog

--- a/site/profile/manifests/core/node_info.pp
+++ b/site/profile/manifests/core/node_info.pp
@@ -1,0 +1,22 @@
+# @summary
+#   This empty class exists solely as a vehicle for shipping enc data to puppetdb.
+#
+#   Note that the facts hash does not contain enc parameters and they must be
+#   accessed as top scoped variables.
+#
+# @param site
+# @param role
+# @param cluster
+# @param variant
+# @param subvariant
+#
+# lint:ignore:top_scope_facts
+class profile::core::node_info (
+  Optional[String[1]] $site = $::site,
+  Optional[String[1]] $role = $::role,
+  Optional[String[1]] $cluster = $::cluster,
+  Optional[String[1]] $variant = $::variant,
+  Optional[String[1]] $subvariant = $::subvariant,
+) {
+# lint:endignore
+}

--- a/spec/classes/ccs/common_spec.rb
+++ b/spec/classes/ccs/common_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 describe 'profile::ccs::common' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { override_facts(os_facts, site: 'ls') }
+      let(:facts) { os_facts }
+      let(:node_params) { { site: 'ls' } }
       let(:pre_condition) do
         <<~PP
           include ssh

--- a/spec/classes/ccs/el9_spec.rb
+++ b/spec/classes/ccs/el9_spec.rb
@@ -7,7 +7,8 @@ describe 'profile::ccs::el9' do
     next unless os =~ %r{almalinux-9-x86_64}
 
     context "on #{os}" do
-      let(:facts) { override_facts(os_facts, site: 'ls') }
+      let(:facts) { os_facts }
+      let(:node_params) { { site: 'ls' } }
       let(:pre_condition) do
         <<~PP
           include ssh

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,14 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = :warning
   end
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
+  # stub out enc parameters which will show up as top level variables, if set.
+  c.default_node_params = {
+    role: nil,
+    site: nil,
+    cluster: nil,
+    variant: nil,
+    subvariant: nil,
+  }
 end
 
 # Disable rspec-puppet coverage reporting which is hardwired as enabled here:
@@ -419,6 +427,18 @@ shared_examples 'common' do |os_facts:, site:, no_auth: false, chrony: true, net
 
   it { is_expected.to contain_class('systemd').with_manage_udevd(true) }
   it { is_expected.to contain_class('sudo').with_purge(true) }
+
+  # All host spec are expected to set the role & site node params. The other
+  # node params will vary per host spec.
+  it do
+    is_expected.to contain_class('profile::core::node_info').with(
+      role: node_params[:role],
+      site: node_params[:site],
+      cluster: node_params[:cluster],
+      variant: node_params[:variant],
+      subvariant: node_params[:subvariant],
+    )
+  end
 end
 
 shared_examples 'lhn sysctls', :lhn_node do


### PR DESCRIPTION
This empty class exists solely as a vehicle for shipping enc data to puppetdb.

Related to https://github.com/lsst-it/k8s-cookbook/pull/300