### PR TITLE
(site/dev) rm rsyslog -> opensearch

### DIFF
--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -16,21 +16,6 @@ rsyslog::config::actions:
       StreamDriver: "ossl"
       StreamDriverMode: "1"
       StreamDriverAuthMode: "anon"
-  opensearch:
-    type: "omelasticsearch"
-    facility: "*.*"
-    config:
-      server: "opensearch.ayekan.dev.lsst.org"
-      serverport: 443
-      usehttps: "on"
-      allowunsignedcerts: "on"  # off for prod
-      searchIndex: "rsyslog-hosts"
-      bulkmode: "on"
-      maxbytes: "100m"
-      queue.type: "linkedlist"
-      queue.size: "5000"
-      queue.dequeuebatchsize: "300"
-      action.resumeretrycount: "-1"
 # The following keys are shared between the `dhcp` and `resolv_conf` classes:
 # - dhcp::dnsdomain
 # - dhcp::nameservers

--- a/spec/support/spec/rsyslog.rb
+++ b/spec/support/spec/rsyslog.rb
@@ -118,26 +118,6 @@ shared_examples 'rsyslog defaults' do |site:|
         },
       )
     end
-
-    it do
-      is_expected.to contain_rsyslog__component__action('opensearch').with(
-        type: 'omelasticsearch',
-        facility: '*.*',
-        config: {
-          'server' => 'opensearch.ayekan.dev.lsst.org',
-          'serverport' => 443,
-          'allowunsignedcerts' => 'on',
-          'usehttps' => 'on',
-          'searchIndex' => 'rsyslog-hosts',
-          'bulkmode' => 'on',
-          'maxbytes' => '100m',
-          'queue.type' => 'linkedlist',
-          'queue.size' => '5000',
-          'queue.dequeuebatchsize' => '300',
-          'action.resumeretrycount' => '-1',
-        },
-      )
-    end
   when 'tu'
     it do
       is_expected.to contain_rsyslog__component__action('graylogtu').with(


### PR DESCRIPTION
As we are already pushing syslog to fluentbit, sending direct to openserach is both redundant and broken.  Resolves this error message:

    2024-04-08T15:57:05.883093+00:00 rancher03.dev.lsst.org rsyslogd: omelasticsearch: error in elasticsearch reply: bulkmode insert does not return array, reply is: {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Action/metadata line [1] contains an unknown parameter [_type]"}],"type":"illegal_argument_exception","reason":"Action/metadata line [1] contains an unknown parameter [_type]"},"status":400} [v8.2102.0-117.el9 try https://www.rsyslog.com/e/2218 ]