### PR TITLE
(spec) fix spec/unit/top_level_role_spec.rb

### DIFF
--- a/hieradata/site/cp/role/rpi.yaml
+++ b/hieradata/site/cp/role/rpi.yaml
@@ -1,2 +1,0 @@
----
-profile::core::common::install_telegraf: false

--- a/hieradata/site/dev/role/net-dx.yaml
+++ b/hieradata/site/dev/role/net-dx.yaml
@@ -1,3 +1,0 @@
----
-classes:
-  - "tftp"

--- a/hieradata/site/ls/role/rpi.yaml
+++ b/hieradata/site/ls/role/rpi.yaml
@@ -1,2 +1,0 @@
----
-profile::core::common::install_telegraf: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,13 +41,13 @@ def puppetfile_path
 end
 
 # extract public hiera hierarchy
-def public_hierarchy
+def hiera_public_hierarchy
   hc = YAML.load_file(control_hiera_config)
-  hc['hierarchy'][1]['paths']
+  hc['hierarchy'].find { |h| h['name'] == 'public hiera' }['paths']
 end
 
 def hiera_all_files
-  public_hierarchy.map { |l| hiera_files_in_layer(l) }.flatten
+  hiera_public_hierarchy.map { |l| hiera_files_in_layer(l) }.flatten
 end
 
 default_facts = {
@@ -71,7 +71,7 @@ end
 
 # all hiera role layers
 def hiera_role_layers
-  public_hierarchy.grep(%r{role})
+  hiera_public_hierarchy.grep(%r{role})
 end
 
 def hiera_files_in_layer(layer)


### PR DESCRIPTION
This spec was broken by the migration to eyaml.