### PR TITLE
(site/cp/cluster/rancher) add network config

### DIFF
--- a/hieradata/site/cp/cluster/rancher.yaml
+++ b/hieradata/site/cp/cluster/rancher.yaml
@@ -1,0 +1,26 @@
+---
+nm::connections:
+  enp1s0:  # fqdn
+    content:
+      connection:
+        id: "enp1s0"
+        uuid: "a79e6dc7-7679-3237-a351-49132a22e919"
+        type: "ethernet"
+        interface-name: "enp1s0"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+  enp2s0:
+    content:
+      connection:
+        id: "enp2s0"
+        uuid: "f6785b81-b268-3d77-bd7a-5833f9851108"
+        type: "ethernet"
+        interface-name: "enp2s0"
+      ethernet: {}
+      ipv4:
+        method: "disabled"
+      ipv6:
+        method: "disabled"

--- a/hieradata/site/cp/cluster/rancher/role/rke.yaml
+++ b/hieradata/site/cp/cluster/rancher/role/rke.yaml
@@ -1,0 +1,4 @@
+---
+classes:
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false

--- a/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
@@ -38,7 +38,29 @@ describe 'rancher01.cp.lsst.org', :sitepp do
       end
 
       include_examples 'vm'
-      it { is_expected.to have_nm__connection_resource_count(0) }
+      include_context 'with nm interface'
+      it do
+        is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
+      end
+
+      it { is_expected.to have_nm__connection_resource_count(2) }
+
+      context 'with enp1s0' do
+        let(:interface) { 'enp1s0' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it_behaves_like 'nm dhcp interface'
+      end
+
+      context 'with enp2s0' do
+        let(:interface) { 'enp2s0' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['method']).to eq('disabled') }
+        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+      end
     end # on os
   end # on_supported_os
 end

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -49,8 +49,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
         it_behaves_like 'nm enabled interface'
         it_behaves_like 'nm ethernet interface'
-        it { expect(nm_keyfile['ipv4']['method']).to eq('auto') }
-        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
+        it_behaves_like 'nm dhcp interface'
       end
 
       context 'with enp2s0' do


### PR DESCRIPTION
To support multiple networks during the migration to `IT-CORE-SERVICES`.