### PR TITLE
(cluster/{yagan,yepun}) bump rke to 1.4.6

### DIFF
--- a/hieradata/cluster/yagan.yaml
+++ b/hieradata/cluster/yagan.yaml
@@ -3,4 +3,3 @@ clustershell::groupmembers:
   yagan: {group: "yagan", member: "yagan[01-20]"}
 profile::core::rke::enable_dhcp: true
 profile::core::ospl::enable_rundir: true
-profile::core::rke::version: "1.3.12"

--- a/hieradata/cluster/yepun.yaml
+++ b/hieradata/cluster/yepun.yaml
@@ -1,4 +1,3 @@
 ---
 clustershell::groupmembers:
   yepun: {group: "yepun", member: "yepun[01-05]"}
-profile::core::rke::version: "1.3.12"

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -51,8 +51,8 @@ describe 'yagan01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.3.12',
-          checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          version: '1.4.6',
+          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
         )
       end
 

--- a/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
@@ -50,8 +50,8 @@ describe 'yagan11.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.3.12',
-          checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          version: '1.4.6',
+          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
         )
       end
 

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.3.12',
-          checksum: '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+          version: '1.4.6',
+          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
         )
       end
 


### PR DESCRIPTION
to support k8s v1.25.9-rancher2-2