### PR TITLE
(role/foreman) disable Foreman_global_parameter[disk_enc_tang_servers]

### DIFF
--- a/hieradata/site/cp/role/foreman.yaml
+++ b/hieradata/site/cp/role/foreman.yaml
@@ -4,10 +4,10 @@ profile::core::foreman::foreman_hostgroup:
     description: "cp site"
 profile::core::foreman::smee_url: "https://smee.io/lpxrggGObEn5YTA"
 puppet::server::puppetdb::server: "puppetdb.cp.lsst.org"
-profile::core::foreman::foreman_global_parameter:
-  disk_enc_tang_servers:  # XXX not idempotent
-    parameter_type: "json"
-    value: '["tang01.cp.lsst.org:7500", "tang02.cp.lsst.org:7500", "tang03.cp.lsst.org:7500"]'
+#profile::core::foreman::foreman_global_parameter:
+#  disk_enc_tang_servers:  # XXX not idempotent
+#    parameter_type: "json"
+#    value: '["tang01.cp.lsst.org:7500", "tang02.cp.lsst.org:7500", "tang03.cp.lsst.org:7500"]'
 
 r10k::sources:
   control:

--- a/hieradata/site/dev/role/foreman.yaml
+++ b/hieradata/site/dev/role/foreman.yaml
@@ -4,10 +4,10 @@ profile::core::foreman::foreman_hostgroup:
     description: "dev site"
 profile::core::foreman::smee_url: "https://smee.io/lpxrggGObEn5YTA"
 puppet::server::puppetdb::server: "puppetdb.dev.lsst.org"
-profile::core::foreman::foreman_global_parameter:
-  disk_enc_tang_servers:  # XXX not idempotent
-    parameter_type: "json"
-    value: '["tang01.dev.lsst.org:7500", "tang02.dev.lsst.org:7500", "tang03.dev.lsst.org:7500"]'
+# profile::core::foreman::foreman_global_parameter:
+#   disk_enc_tang_servers:  # XXX not idempotent
+#     parameter_type: "json"
+#     value: '["tang01.dev.lsst.org:7500", "tang02.dev.lsst.org:7500", "tang03.dev.lsst.org:7500"]'
 
 r10k::sources:
   control:

--- a/hieradata/site/ls/role/foreman.yaml
+++ b/hieradata/site/ls/role/foreman.yaml
@@ -4,10 +4,10 @@ profile::core::foreman::foreman_hostgroup:
     description: "ls site"
 profile::core::foreman::smee_url: "https://smee.io/lpxrggGObEn5YTA"
 puppet::server::puppetdb::server: "puppetdb.ls.lsst.org"
-profile::core::foreman::foreman_global_parameter:
-  disk_enc_tang_servers:  # XXX not idempotent
-    parameter_type: "json"
-    value: '["tang01.ls.lsst.org:7500", "tang02.ls.lsst.org:7500", "tang03.ls.lsst.org:7500"]'
+#profile::core::foreman::foreman_global_parameter:
+#  disk_enc_tang_servers:  # XXX not idempotent
+#    parameter_type: "json"
+#    value: '["tang01.ls.lsst.org:7500", "tang02.ls.lsst.org:7500", "tang03.ls.lsst.org:7500"]'
 
 r10k::sources:
   control:

--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -17,10 +17,10 @@ profile::core::foreman::foreman_hostgroup:
 
 profile::core::foreman::smee_url: "https://smee.io/lpxrggGObEn5YTA"
 puppet::server::puppetdb::server: "puppetdb.tu.lsst.org"
-profile::core::foreman::foreman_global_parameter:
-  disk_enc_tang_servers:  # XXX not idempotent
-    parameter_type: "json"
-    value: '["tang01.tu.lsst.org:7500", "tang02.tu.lsst.org:7500", "tang03.tu.lsst.org:7500"]'
+#profile::core::foreman::foreman_global_parameter:
+#  disk_enc_tang_servers:  # XXX not idempotent
+#    parameter_type: "json"
+#    value: '["tang01.tu.lsst.org:7500", "tang02.tu.lsst.org:7500", "tang03.tu.lsst.org:7500"]'
 
 r10k::sources:
   control:


### PR DESCRIPTION
As this resource isn't idempotent.  However, the configuration is retained as commented out as this configuration is required when re-provisioning a foreman host.