### PR TITLE
(profile/archive) remove sysctl:lhn

### DIFF
--- a/site/profile/manifests/archive/common.pp
+++ b/site/profile/manifests/archive/common.pp
@@ -26,7 +26,6 @@ class profile::archive::common (
   include profile::core::docker::prune
   include profile::core::nfsclient
   include profile::core::nfsserver
-  include profile::core::sysctl::lhn
 
   if $packages {
     ensure_packages($packages)

--- a/spec/hosts/roles/auxtel_archiver_spec.rb
+++ b/spec/hosts/roles/auxtel_archiver_spec.rb
@@ -25,7 +25,6 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', os_facts: os_facts, site: site
-          include_examples 'lhn sysctls'
           include_examples 'archiver'
           include_examples 'docker'
           include_examples 'archive data auxtel'

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -25,7 +25,6 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', os_facts: os_facts, site: site
-          include_examples 'lhn sysctls'
           include_examples 'archiver'
           include_examples 'docker'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -487,7 +487,6 @@ shared_examples 'archiver', :archiver do
     profile::core::docker::prune
     profile::core::nfsclient
     profile::core::nfsserver
-    profile::core::sysctl::lhn
   ].each do |c|
     it { is_expected.to contain_class(c) }
   end


### PR DESCRIPTION
there were some corrective issues when running Puppet on the archives, so we decided to remove the class from the archive profile