### PR TITLE
(rubocop) exclude "vendor"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
   - "spec/fixtures/**/*"
   - "**/Vagrantfile"
   - ".vendor/**/*"
+  - "vendor/**/*"
 Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200


### PR DESCRIPTION
Currently only ".vendor" is being excluded, but prior to 81cf968 both were.
.gitignore only ignores "vendor".

Otherwise rubocop descends into the vendor directory, which caused me a lot of problems.
