### PR TITLE
(site/cp) bump rke to 1.5.8

### DIFF
--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -23,7 +23,7 @@ profile::core::helm::version: "3.5.4"
 profile::core::kernel::debuginfo: true
 profile::core::kernel::devel: true
 profile::core::common::manage_node_exporter: false
-profile::core::rke::version: "1.4.6"
+profile::core::rke::version: "1.5.8"
 
 files:
   /home/rke/.bash_profile:

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -13,7 +13,7 @@
 class profile::core::rke (
   Boolean                        $enable_dhcp   = false,
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
-  String                         $version       = '1.4.6',
+  String                         $version       = '1.5.8',
 ) {
   include kmod
   require ipa

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -29,8 +29,8 @@ describe 'profile::core::rke' do
 
         it do
           is_expected.to contain_class('rke').with(
-            version: '1.4.6',
-            checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+            version: '1.5.8',
+            checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
           )
         end
       end

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
@@ -32,8 +32,8 @@ describe 'rancher01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -51,8 +51,8 @@ describe 'yagan01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
@@ -50,8 +50,8 @@ describe 'yagan11.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.4.6',
-          checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
+          version: '1.5.8',
+          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -35,20 +35,11 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  if (site == 'dev') || (site == 'tu') || (site == 'ls')
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.5.8',
-        checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
-      )
-    end
-  else
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.4.6',
-        checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
-      )
-    end
+  it do
+    is_expected.to contain_class('rke').with(
+      version: '1.5.8',
+      checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+    )
   end
 end
 


### PR DESCRIPTION
Bumping rke client version on CP clusters to 1.5.8