### PR TITLE
(role/hypervisor) set /vm to 0750 qemu:qemu

### DIFF
--- a/hieradata/role/hypervisor.yaml
+++ b/hieradata/role/hypervisor.yaml
@@ -36,6 +36,11 @@ files:
     owner: "root"
     group: "root"
     mode: "0644"
+  /vm:
+    ensure: "directory"
+    owner: "qemu"
+    group: "qemu"
+    mode: "0750"
 ssh::server::match_block:
   foreman:
     type: "user"

--- a/spec/hosts/roles/hypervisor_spec.rb
+++ b/spec/hosts/roles/hypervisor_spec.rb
@@ -82,6 +82,15 @@ describe "#{role} role" do
               end
             end
           end
+
+          it do
+            is_expected.to contain_file('/vm').with(
+              ensure: 'directory',
+              owner: 'qemu',
+              group: 'qemu',
+              mode: '0750',
+            )
+          end
         end # host
       end # lsst_sites
     end


### PR DESCRIPTION
Resolves:
    
    virsh # start foreman
    error: Failed to start domain 'foreman'
    error: internal error: process exited while connecting to monitor: 2024-05-22T15:06:01.032485Z qemu-kvm: -blockdev {"driver":"file","filename":"/vm/foreman.qcow2","node-name":"libvirt-2-storage","auto-read-only":true,"discard":"unmap"}: Could not open '/vm/foreman.qcow2': Permission denied
