### PR TITLE
(profile::core::yum::lsst_ts_private) allow username to be Sensitive

### DIFF
--- a/site/profile/manifests/core/yum/lsst_ts_private.pp
+++ b/site/profile/manifests/core/yum/lsst_ts_private.pp
@@ -12,12 +12,13 @@
 #
 class profile::core::yum::lsst_ts_private (
   Optional[Hash] $repos      = undef,
-  Optional[String[1]] $username = undef,
+  Optional[Variant[Sensitive[String[1]],String[1]]] $username = undef,
   Optional[Sensitive[String[1]]] $password = undef,
 ) {
   if $repos {
     $_real_repos = $repos.map |String $k, Hash $h| {
-      [$k, $h + { username => $username, password => $password }]
+      # yumrepo supports password as Sensitive but not username
+      [$k, $h + { username => $username.unwrap, password => $password }]
     }
     create_resources('yumrepo', Hash($_real_repos))
   }

--- a/spec/classes/core/yum/lsst_ts_private_spec.rb
+++ b/spec/classes/core/yum/lsst_ts_private_spec.rb
@@ -21,10 +21,31 @@ describe 'profile::core::yum::lsst_ts_private' do
         end
       end
 
-      context 'with username & password param' do
+      context 'with username & password param (Sensitive)' do
         let(:params) do
           {
             username: 'foo',
+            password: sensitive('bar'),
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_yumrepo('lsst-ts-private').with(
+            descr: 'LSST Telescope and Site Private Packages',
+            ensure: 'present',
+            enabled: true,
+            username: 'foo',
+            password: sensitive('bar'),
+          )
+        end
+      end
+
+      context 'with username (Sensitive) & password param (Sensitive)' do
+        let(:params) do
+          {
+            username: sensitive('foo'),
             password: sensitive('bar'),
           }
         end


### PR DESCRIPTION
To resolve this error:

    Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Class[Profile::Core::Yum::Lsst_ts_private]: parameter 'username' expects a value of type Undef or String, got Sensitive[String] (file: /etc/puppetlabs/code/environments/cp_production/site/profile/manifests/ts/opensplicedds.pp, line: 10, column: 3) on node sal-dx.cp.lsst.org