### PR TITLE
(profile::ccs::graphical) tweak installed desktop apps

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,7 +10,6 @@ mod 'derdanne/nfs', git: 'https://github.com/lsst-it/puppet-nfs', ref: '6d51f51'
 mod 'duritong/sysctl', git: 'https://github.com/duritong/puppet-sysctl', ref: '847ec1c'  # migrate to herculesteam/augeasproviders_sysctl; https://github.com/duritong/puppet-sysctl/pull/48
 mod 'example42/network', git: 'https://github.com/lsst-it/puppet-network', ref: 'c2b5c59'  # allow stdlib/concat 9.x
 mod 'fervid/snapd', '1.2.1' # 2021-05-31 hreinking: snapd for EAS Raspberry Pi
-mod 'jamesnetherton/google_chrome', '0.10.0'
 mod 'jamtur01/httpauth', '0.0.6'
 mod 'jcpunk/irqbalance', '1.0.5'
 mod 'jhoblitt/ipmi', '5.2.0'
@@ -24,6 +23,7 @@ mod 'lsst/cni', '3.2.0'
 mod 'lsst/daq', '2.3.0'
 mod 'lsst/dellperc', '2.0.0'
 mod 'lsst/foreman_envsync', '2.1.0'
+mod 'lsst/google_chrome', git: 'https://github.com/lsst-it/puppet-google-chrome', ref: '974a7b1'
 mod 'lsst/helm_binary', '2.1.0'
 mod 'lsst/htcondor', '0.1.0'
 mod 'lsst/ipa', git: 'https://github.com/lsst-it/puppet-ipa', ref: '37eb701'

--- a/Puppetfile
+++ b/Puppetfile
@@ -10,6 +10,7 @@ mod 'derdanne/nfs', git: 'https://github.com/lsst-it/puppet-nfs', ref: '6d51f51'
 mod 'duritong/sysctl', git: 'https://github.com/duritong/puppet-sysctl', ref: '847ec1c'  # migrate to herculesteam/augeasproviders_sysctl; https://github.com/duritong/puppet-sysctl/pull/48
 mod 'example42/network', git: 'https://github.com/lsst-it/puppet-network', ref: 'c2b5c59'  # allow stdlib/concat 9.x
 mod 'fervid/snapd', '1.2.1' # 2021-05-31 hreinking: snapd for EAS Raspberry Pi
+mod 'jamesnetherton/google_chrome', '0.10.0'
 mod 'jamtur01/httpauth', '0.0.6'
 mod 'jcpunk/irqbalance', '1.0.5'
 mod 'jhoblitt/ipmi', '5.2.0'

--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -61,7 +61,19 @@ class profile::ccs::graphical (
         timeout => 900,
         notify  => Package[$unwanted_gnome_pkgs],
       }
-      ensure_packages(['mate-desktop'])
+      ## There doesn't seem to be a group for this in epel9.
+      ensure_packages([
+          'mate-desktop',
+          'mate-applets',
+          'mate-menu',
+          'mate-panel',
+          'mate-session-manager',
+          'mate-terminal',
+          'mate-themes',
+          'mate-utils',
+          'marco',
+          'caja',
+      ])
     }
 
     package { $unwanted_gnome_pkgs:

--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -72,24 +72,7 @@ class profile::ccs::graphical (
   }
 
   if $officeapps {
-    ensure_packages(['libreoffice-base', 'ibus-m17n', 'libXScrnSaver'])
-
-    $zoomrpm = 'zoom.x86_64.rpm'
-    $zoomfile = "/var/tmp/${zoomrpm}"
-
-    archive { $zoomfile:
-      ensure   => present,
-      source   => "${profile::ccs::common::pkgurl}/${zoomrpm}",
-      username => $profile::ccs::common::pkgurl_user.unwrap,
-      password => $profile::ccs::common::pkgurl_pass.unwrap,
-    }
-
-    ## TODO use a local yum repository?
-    package { 'zoom':
-      ensure   => 'installed',
-      provider => 'rpm',
-      source   => $zoomfile,
-    }
+    ensure_packages(['libreoffice-base'])
 
     if fact('os.release.major') == '9' {
       include 'google_chrome'

--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -90,5 +90,9 @@ class profile::ccs::graphical (
       provider => 'rpm',
       source   => $zoomfile,
     }
+
+    if fact('os.release.major') == '9' {
+      include 'google_chrome'
+    }
   }
 }


### PR DESCRIPTION
Add google-chrome, drop zoom.
There was a mild request to add the slack desktop client, but I find slack in a browser works fine on Linux.
The fact that there seems to be no active forge module for the slack client seems like a sign.
