### PR TITLE
(cluster/comcam-ccs) no longer install old ccs releases

### DIFF
--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -91,26 +91,6 @@ accounts::user_list:
 ccs_software::desktop: true
 ccs_software::env: "ComCam"
 ccs_software::installations:
-  comcam-software-2.4.2:
-    aliases:
-      - "puppet-2.4.2"
-
-  comcam-software-2.4.3:
-    aliases:
-      - "puppet-2.4.3"
-
-  comcam-software-2.4.4:
-    aliases:
-      - "puppet-2.4.4"
-
-  comcam-software-2.4.5:
-    aliases:
-      - "puppet-2.4.5"
-
-  comcam-software-2.4.6:
-    aliases:
-      - "puppet-2.4.6"
-
   comcam-software-2.4.7:
     aliases:
       - "puppet-2.4.7"


### PR DESCRIPTION
This will speed up reinstallations.