### PR TITLE
(rsyslog::config::actions) stop writing to /-/var/log/maillog

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -307,7 +307,7 @@ rsyslog::config::actions:
     type: "omfile"
     facility: "mail.*"
     config:
-      file: "-/var/log/maillog"
+      file: "/var/log/maillog"
   cron:
     type: "omfile"
     facility: "cron.*"

--- a/spec/support/spec/rsyslog.rb
+++ b/spec/support/spec/rsyslog.rb
@@ -39,7 +39,7 @@ shared_examples 'rsyslog defaults' do |site:|
       type: 'omfile',
       facility: 'mail.*',
       config: {
-        'file' => '-/var/log/maillog',
+        'file' => '/var/log/maillog',
       },
     )
   end


### PR DESCRIPTION
The leading "-" in rsyslog was an old way to disable sync-on-write. However, this has been off by default since rsyslog v3 (c 2008). It seems that in practice the result has been to write maillog to "/-/var/log/maillog". Perhaps the special meaning of a leading "-" was dropped sometime in the past decade.

Ref:
https://lsstc.slack.com/archives/C06V270ECBW/p1717180543799339
https://serverfault.com/questions/463170/what-does-filepath-action-mean-in-rsyslog-configuration
https://www.rsyslog.com/doc/compatibility/v3compatibility.html#output-file-syncing
