### PR TITLE
(site/ls) update ccs clusters for cycle 37

### DIFF
--- a/hieradata/site/ls/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/ls/cluster/auxtel-ccs.yaml
@@ -2,6 +2,9 @@
 ccs_site: "base"
 ccs_sal::dds_interface: "auxtel-mcm-dds.ls.lsst.org"
 
+ccs_sal::rpms:
+  ts_sal_utils: "ts_sal_utils-8.0.0-1.x86_64.rpm"
+
 ## base-teststand-alerts
 ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
 

--- a/hieradata/site/ls/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/ls/cluster/auxtel-ccs.yaml
@@ -6,9 +6,9 @@ ccs_sal::dds_interface: "auxtel-mcm-dds.ls.lsst.org"
 ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
 
 ccs_software::installations:
-  ats-software-2.3.7:
+  ats-software-2.3.10:
     aliases:
-      - "puppet-2.3.7"
+      - "puppet-2.3.10"
 
 ccs_monit::alert:
   - "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"

--- a/hieradata/site/ls/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/ls/cluster/lsstcam-ccs.yaml
@@ -2,6 +2,9 @@
 ccs_site: "base"
 ccs_sal::dds_interface: "lsstcam-mcm-dds.ls.lsst.org"
 
+ccs_sal::rpms:
+  ts_sal_utils: "ts_sal_utils-8.0.0-1.x86_64.rpm"
+
 ## base-teststand-alerts
 ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
 

--- a/hieradata/site/ls/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/ls/cluster/lsstcam-ccs.yaml
@@ -7,3 +7,8 @@ ccs_software::service_email: "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@l
 
 ccs_monit::alert:
   - "base-teststand-alerts-aaaai5j4osevcaaobtog67nxlq@lsstc.slack.com"
+
+ccs_software::installations:
+  lsstcam-software-1.0.11:
+    aliases:
+      - "puppet-1.0.11"


### PR DESCRIPTION
As written, this only affects BTS.
~It installs an EL7 version of OpenSplice-DDS, because at time of writing this is the only flavour of the cycle 37 version (6.10.4-6) that exists. I don't yet know if this will install on EL9 (probably).~
It turns out this was a typo on the cycle 37 page, and no OpenSpliceDDS change is needed.