### PR TITLE
(profile::ccs::home) handle EL8+ login.defs home dir perms

### DIFF
--- a/site/profile/manifests/ccs/home.pp
+++ b/site/profile/manifests/ccs/home.pp
@@ -4,7 +4,13 @@ class profile::ccs::home {
   ## rather than each having their own?
   file_line { 'Change default home permissions':
     path  => '/etc/login.defs',
-    match => '^UMASK ',
+    match => '^UMASK\s',
     line  => 'UMASK 022',
+  }
+  file_line { 'Change default home permissions for EL8+':
+    path               => '/etc/login.defs',
+    match              => '^HOME_MODE\s',
+    line               => 'HOME_MODE 0755',
+    append_on_no_match => false,
   }
 }


### PR DESCRIPTION
To make new home directories world-readable by default in EL8+, it is necessary to modify HOME_MODE in /etc/login.defs.