### PR TITLE
(node/lsstcam-fb02.cp) enable ccs_hcu canbus support for EL9

### DIFF
--- a/hieradata/node/lsstcam-fb02.cp.lsst.org.yaml
+++ b/hieradata/node/lsstcam-fb02.cp.lsst.org.yaml
@@ -1,0 +1,2 @@
+---
+ccs_hcu::canbus: true

--- a/hieradata/role/ccs-hcu/osfamily/RedHat/major/9.yaml
+++ b/hieradata/role/ccs-hcu/osfamily/RedHat/major/9.yaml
@@ -1,0 +1,3 @@
+---
+ccs_hcu::canbus::module: "advSocketCAN"
+ccs_hcu::canbus::version: "3.0.2.2"


### PR DESCRIPTION
Note:
currently these changes are contained within the branch IT-5425_lsstcam_fb02_el9