### PR TITLE
(node/lsstcam-dc02.cp) disable ccs image-handling service

### DIFF
--- a/hieradata/node/lsstcam-dc02.cp.lsst.org.yaml
+++ b/hieradata/node/lsstcam-dc02.cp.lsst.org.yaml
@@ -20,3 +20,12 @@ nm::connections:
       method=ignore
 
       [proxy]
+
+## The role ccs-dc adds the image-handling service to all lsstcam-dc*.cp nodes.
+## However, dc02.cp is a special case, where the service should not be present.
+lookup_options:
+  ccs_software::services:
+    merge:
+      strategy: "first"
+
+ccs_software::services:

--- a/hieradata/site/cp/cluster/lsstcam-ccs/role/ccs-dc.yaml
+++ b/hieradata/site/cp/cluster/lsstcam-ccs/role/ccs-dc.yaml
@@ -11,6 +11,10 @@ files:
     owner: &ccsipauser 72055
     group: *ccsipauser
 
+## Note: node/lsstcam-dc02.cp should not have image-handling,
+## and so specifically redefines services to be empty.
+## If you want to add more services here, they will also need to be
+## added to that node.
 ccs_software::services:
   prod:
     - {name: "image-handling", user: "ccs-ipa", group: "ccs-ipa", workdir: "/home/ccs-ipa"}

--- a/spec/hosts/nodes/lsstcam-dc02.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc02.cp.lsst.org_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'lsstcam-dc02.cp.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next if os =~ %r{centos-7-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        override_facts(os_facts,
+                       fqdn: 'lsstcam-dc02.cp.lsst.org',
+                       is_virtual: false,
+                       virtual: 'physical',
+                       dmi: {
+                         'product' => {
+                           'name' => 'PowerEdge R6515',
+                         },
+                       })
+      end
+      let(:node_params) do
+        {
+          role: 'ccs-dc',
+          cluster: 'lsstcam-ccs',
+          site: 'cp',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'baremetal'
+
+      it { is_expected.not_to contain_service('image-handling') }
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
This replaces pull #1202 