### PR TITLE
(Gemfile) pin facterdb < 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :test do
   gem 'puppet-lint-unquoted_string-check', '~> 2.1.0',         require: false
   gem 'puppet-lint-variable_contains_upcase', '~> 1.2.0',      require: false
 
+  gem 'facterdb', '< 2', require: false # 3.0.0 drops support for EL7
+
   gem 'r10k',    require: false
   gem 'toml-rb', require: false # puppet/telegraf
 end


### PR DESCRIPTION
Facterdb 3.x dropps support for EL7.  facterdb 2.1.0 also seems to fail. Thus, we are pinning facterdb to 1.x until support for EL7 is removed from this repo.