### PR TITLE
(role/rke) bump CP client to v1.5.9

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,2 +1,0 @@
----
-profile::core::rke::version: "1.5.9"

--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,3 +1,2 @@
 ---
 profile::core::docker::version: "24.0.9"
-profile::core::rke::version: "1.5.9"

--- a/hieradata/site/tu/role/rke.yaml
+++ b/hieradata/site/tu/role/rke.yaml
@@ -1,3 +1,2 @@
 ---
 profile::core::docker::version: "24.0.9"
-profile::core::rke::version: "1.5.9"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -13,7 +13,7 @@
 class profile::core::rke (
   Boolean                        $enable_dhcp   = false,
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
-  String                         $version       = '1.5.8',
+  String                         $version       = '1.5.9',
 ) {
   include kmod
   require ipa

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -29,8 +29,8 @@ describe 'profile::core::rke' do
 
         it do
           is_expected.to contain_class('rke').with(
-            version: '1.5.8',
-            checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+            version: '1.5.9',
+            checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
           )
         end
       end

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
@@ -32,8 +32,8 @@ describe 'rancher01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -51,8 +51,8 @@ describe 'yagan01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
@@ -50,8 +50,8 @@ describe 'yagan11.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.8',
-          checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+          version: '1.5.9',
+          checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -35,21 +35,11 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  case site
-  when 'dev', 'tu', 'ls'
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.5.9',
-        checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
-      )
-    end
-  else
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.5.8',
-        checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
-      )
-    end
+  it do
+    is_expected.to contain_class('rke').with(
+      version: '1.5.9',
+      checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
+    )
   end
 end
 


### PR DESCRIPTION
bump the rke client to move k8s version to v1.28.9