### PR TITLE
(Puppet) Remove sysstat package from hosts.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -98,7 +98,6 @@ mod 'puppet/tang', '0.1.1'
 mod 'puppet/telegraf', '5.2.0'
 mod 'puppet/tuned', '1.0.0'
 mod 'puppet/yum', '7.1.0'
-mod 'qtechnologies/sysstat', '1.2.7'
 mod 'richardc/datacat', '0.6.2'
 mod 'saz/resolv_conf', git: 'https://github.com/lsst-it/puppet-resolv_conf', ref: '5c00538'  # https://github.com/saz/puppet-resolv_conf/pull/72
 mod 'saz/ssh', '11.1.0'

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -84,9 +84,18 @@ class profile::core::common (
   include ssh
   include sudo
   include sysctl::values
-  include sysstat
   include timezone
   include tuned
+
+  # Ensure sysstat package is absent
+  package { 'sysstat':
+    ensure => absent,
+  }
+
+  # Ensure /etc/cron.d/sysstat file is absent
+  file { '/etc/cron.d/sysstat':
+    ensure => absent,
+  }
 
   if fact('os.family') == 'RedHat' {
     include epel


### PR DESCRIPTION
To address the high CPU usage on some nodes making hosts unresponsive, it was decided to remove the sysstat package from our hosts.

Ticket of reference: https://rubinobs.atlassian.net/browse/IT-5490
