### PR TITLE
(role/rke) bump DEV client to v1.5.10

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::rke::version: "1.5.10"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -46,9 +46,9 @@ class profile::core::rke (
   }
 
   $rke_checksum = $version ? {
-    '1.4.6'     => '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
-    '1.5.8'     => 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
-    '1.5.9'     => '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
+    '1.5.8'      => 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
+    '1.5.9'      => '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
+    '1.5.10'     => 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -103,25 +103,6 @@ describe 'profile::core::rke' do
       end
 
       context 'with version param' do
-        context 'when 1.4.6' do
-          let(:params) do
-            {
-              version: '1.4.6',
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          include_examples 'rke profile'
-
-          it do
-            is_expected.to contain_class('rke').with(
-              version: '1.4.6',
-              checksum: '12d8fee6f759eac64b3981ef2822353993328f2f839ac88b3739bfec0b9d818c',
-            )
-          end
-        end
-
         context 'when 1.5.8' do
           let(:params) do
             {
@@ -156,6 +137,25 @@ describe 'profile::core::rke' do
             is_expected.to contain_class('rke').with(
               version: '1.5.9',
               checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
+            )
+          end
+        end
+
+        context 'when 1.5.10' do
+          let(:params) do
+            {
+              version: '1.5.10',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
+
+          it do
+            is_expected.to contain_class('rke').with(
+              version: '1.5.10',
+              checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
             )
           end
         end

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'ayekan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.9',
+          version: '1.5.10',
         )
       end
 

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.9',
+          version: '1.5.10',
         )
       end
 

--- a/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'namkueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.9',
+          version: '1.5.10',
         )
       end
 

--- a/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
@@ -32,7 +32,7 @@ describe 'rancher01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.9',
+          version: '1.5.10',
         )
       end
 

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -52,7 +52,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.9',
+          version: '1.5.10',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -42,11 +42,21 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  it do
-    is_expected.to contain_class('rke').with(
-      version: '1.5.9',
-      checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
-    )
+  case site
+  when 'dev'
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.5.10',
+        checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.5.9',
+        checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
+      )
+    end
   end
 end
 


### PR DESCRIPTION
bump rke client to 1.5.10 on Dev, except for ruka, since now it is running rke2.