### PR TITLE
(profile::core::k8snode) split out of profile::core::rke

### DIFF
--- a/hieradata/cluster/chonchon.yaml
+++ b/hieradata/cluster/chonchon.yaml
@@ -1,7 +1,7 @@
 ---
 clustershell::groupmembers:
   chonchon: {group: "chonchon", member: "chonchon[01-03]"}
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   em1:
     content: |

--- a/hieradata/cluster/konkong.yaml
+++ b/hieradata/cluster/konkong.yaml
@@ -2,7 +2,7 @@
 clustershell::groupmembers:
   konkong: {group: "konkong", member: "konkong[01-03]"}
 profile::core::ospl::enable_rundir: true
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   eno1np0:
     content: |

--- a/hieradata/cluster/kueyen.yaml
+++ b/hieradata/cluster/kueyen.yaml
@@ -2,7 +2,7 @@
 clustershell::groupmembers:
   kueyen: {group: "kueyen", member: "kueyen[01-03]"}
 profile::core::ospl::enable_rundir: true
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   em1:  #PXE Boot
     content: |

--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -4,7 +4,7 @@ clustershell::groupmembers:
     group: "manke"
     member: "manke[01-10]"
 profile::core::ospl::enable_rundir: true
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   eno1np0:
     content:

--- a/hieradata/cluster/pillan.yaml
+++ b/hieradata/cluster/pillan.yaml
@@ -2,7 +2,7 @@
 clustershell::groupmembers:
   pillan: {group: "pillan", member: "pillan[01-09]"}
 profile::core::ospl::enable_rundir: true
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   enp4s0f3u2u2c2:
     content: |

--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -1,7 +1,7 @@
 ---
 clustershell::groupmembers:
   ruka: {group: "ruka", member: "ruka[01-05]"}
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 nm::connections:
   br2101:
     content:

--- a/hieradata/cluster/yagan.yaml
+++ b/hieradata/cluster/yagan.yaml
@@ -1,5 +1,5 @@
 ---
 clustershell::groupmembers:
   yagan: {group: "yagan", member: "yagan[01-20]"}
-profile::core::rke::enable_dhcp: true
+profile::core::k8snode::enable_dhcp: true
 profile::core::ospl::enable_rundir: true

--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -6,6 +6,7 @@ classes:
   - "profile::core::debugutils"
   - "profile::core::docker"
   - "profile::core::helm"
+  - "profile::core::k8snode"
   - "profile::core::kernel::pquota"
   - "profile::core::kubecompletion"
   - "profile::core::ospl"

--- a/site/profile/manifests/core/k8snode.pp
+++ b/site/profile/manifests/core/k8snode.pp
@@ -1,0 +1,23 @@
+# @summary
+#   Common functionality needed by kubernetes nodes.
+#
+# @param enable_dhcp
+#   Enable CNI dhcp plugin
+#
+class profile::core::k8snode (
+  Boolean $enable_dhcp = false,
+) {
+  if $enable_dhcp {
+    include cni::plugins
+    include cni::plugins::dhcp
+  }
+
+  sysctl::value { 'fs.inotify.max_user_instances':
+    value  => 104857,
+    target => '/etc/sysctl.d/80-rke.conf',
+  }
+  sysctl::value { 'fs.inotify.max_user_watches':
+    value  => 1048576,
+    target => '/etc/sysctl.d/80-rke.conf',
+  }
+}

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -1,9 +1,6 @@
 # @summary
 #   Common functionality needed by rke on kubernetes nodes.
 #
-# @param enable_dhcp
-#   Enable CNI dhcp plugin
-#
 # @param keytab_base64
 #   base64 encoded krb5 keytab
 #
@@ -11,7 +8,6 @@
 #   Version of rke utility to install
 #
 class profile::core::rke (
-  Boolean                        $enable_dhcp   = false,
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
   String                         $version       = '1.5.9',
 ) {
@@ -20,11 +16,6 @@ class profile::core::rke (
 
   $user = 'rke'
   $uid  = 75500
-
-  if $enable_dhcp {
-    include cni::plugins
-    include cni::plugins::dhcp
-  }
 
   if $keytab_base64 {
     profile::util::keytab { $user:
@@ -66,13 +57,4 @@ class profile::core::rke (
     target => '/etc/sysctl.d/80-rke.conf',
   }
   -> Class['docker']
-
-  sysctl::value { 'fs.inotify.max_user_instances':
-    value  => 104857,
-    target => '/etc/sysctl.d/80-rke.conf',
-  }
-  sysctl::value { 'fs.inotify.max_user_watches':
-    value  => 1048576,
-    target => '/etc/sysctl.d/80-rke.conf',
-  }
 }

--- a/spec/classes/core/k8snode_spec.rb
+++ b/spec/classes/core/k8snode_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::k8snode' do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with no params' do
+        it { is_expected.to compile.with_all_deps }
+
+        include_examples 'k8snode profile'
+
+        it { is_expected.not_to contain_class('cni::plugins') }
+        it { is_expected.not_to contain_class('cni::plugins::dhcp') }
+      end
+
+      context 'with enable_dhcp param' do
+        context 'when false' do
+          let(:params) do
+            {
+              enable_dhcp: false,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'k8snode profile'
+
+          it { is_expected.not_to contain_class('cni::plugins') }
+          it { is_expected.not_to contain_class('cni::plugins::dhcp') }
+        end
+
+        context 'when true' do
+          let(:params) do
+            {
+              enable_dhcp: true,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'k8snode profile'
+
+          it { is_expected.to contain_class('cni::plugins') }
+          it { is_expected.to contain_class('cni::plugins::dhcp') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -19,9 +19,6 @@ describe 'profile::core::rke' do
 
         include_examples 'rke profile'
 
-        it { is_expected.not_to contain_class('cni::plugins') }
-        it { is_expected.not_to contain_class('cni::plugins::dhcp') }
-
         it do
           is_expected.not_to contain_profile__util__keytab('rke')
             .that_requires('Class[ipa]')
@@ -32,38 +29,6 @@ describe 'profile::core::rke' do
             version: '1.5.9',
             checksum: '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
           )
-        end
-      end
-
-      context 'with enable_dhcp param' do
-        context 'when false' do
-          let(:params) do
-            {
-              enable_dhcp: false,
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          include_examples 'rke profile'
-
-          it { is_expected.not_to contain_class('cni::plugins') }
-          it { is_expected.not_to contain_class('cni::plugins::dhcp') }
-        end
-
-        context 'when true' do
-          let(:params) do
-            {
-              enable_dhcp: true,
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          include_examples 'rke profile'
-
-          it { is_expected.to contain_class('cni::plugins') }
-          it { is_expected.to contain_class('cni::plugins::dhcp') }
         end
       end
 

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -62,6 +62,8 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
         )
       end
 
+      it { is_expected.to contain_class('cni::plugins::dhcp') }
+
       it { is_expected.to have_nm__connection_resource_count(6) }
 
       %w[

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -38,7 +38,6 @@ describe 'pillan01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          enable_dhcp: true,
           version: '1.5.10',
         )
       end
@@ -51,6 +50,7 @@ describe 'pillan01.tu.lsst.org', :sitepp do
         )
       end
 
+      it { is_expected.to contain_class('cni::plugins::dhcp') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(14) }

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -41,7 +41,6 @@ describe 'pillan08.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          enable_dhcp: true,
           version: '1.5.10',
         )
       end
@@ -54,6 +53,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
         )
       end
 
+      it { is_expected.to contain_class('cni::plugins::dhcp') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       # 2 extra instances in the catalog for the rename interfaces

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -64,6 +64,7 @@ describe 'yagan01.cp.lsst.org', :sitepp do
         )
       end
 
+      it { is_expected.to contain_class('cni::plugins::dhcp') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(11) }

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -7,6 +7,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   include_examples 'debugutils'
   include_examples 'docker'
   include_examples 'rke profile'
+  include_examples 'k8snode profile'
   include_examples 'restic common'
 
   it do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -622,37 +622,6 @@ shared_examples 'foreman' do
   end
 end
 
-shared_examples 'rke profile' do
-  it { is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook') }
-
-  it { is_expected.to contain_kmod__load('br_netfilter') }
-
-  it do
-    is_expected.to contain_sysctl__value('net.bridge.bridge-nf-call-iptables').with(
-      value: 1,
-      target: '/etc/sysctl.d/80-rke.conf',
-    ).that_requires('Kmod::Load[br_netfilter]').that_comes_before('Class[docker]')
-  end
-
-  it do
-    is_expected.to contain_sysctl__value('fs.inotify.max_user_instances').with(
-      value: 104_857,
-      target: '/etc/sysctl.d/80-rke.conf',
-    )
-  end
-
-  it do
-    is_expected.to contain_sysctl__value('fs.inotify.max_user_watches').with(
-      value: 1_048_576,
-      target: '/etc/sysctl.d/80-rke.conf',
-    )
-  end
-
-  it do
-    is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook').that_requires('Class[ipa]')
-  end
-end
-
 shared_examples 'generic foreman' do
   include_examples 'debugutils'
   include_examples 'docker'

--- a/spec/support/spec/k8snode.rb
+++ b/spec/support/spec/k8snode.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+shared_examples 'k8snode profile' do
+  it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_user_instances').with(
+      value: 104_857,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+
+  it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_user_watches').with(
+      value: 1_048_576,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+end

--- a/spec/support/spec/rke.rb
+++ b/spec/support/spec/rke.rb
@@ -13,20 +13,6 @@ shared_examples 'rke profile' do
   end
 
   it do
-    is_expected.to contain_sysctl__value('fs.inotify.max_user_instances').with(
-      value: 104_857,
-      target: '/etc/sysctl.d/80-rke.conf',
-    )
-  end
-
-  it do
-    is_expected.to contain_sysctl__value('fs.inotify.max_user_watches').with(
-      value: 1_048_576,
-      target: '/etc/sysctl.d/80-rke.conf',
-    )
-  end
-
-  it do
     is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook').that_requires('Class[ipa]')
   end
 end

--- a/spec/support/spec/rke.rb
+++ b/spec/support/spec/rke.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+shared_examples 'rke profile' do
+  it { is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook') }
+
+  it { is_expected.to contain_kmod__load('br_netfilter') }
+
+  it do
+    is_expected.to contain_sysctl__value('net.bridge.bridge-nf-call-iptables').with(
+      value: 1,
+      target: '/etc/sysctl.d/80-rke.conf',
+    ).that_requires('Kmod::Load[br_netfilter]').that_comes_before('Class[docker]')
+  end
+
+  it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_user_instances').with(
+      value: 104_857,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+
+  it do
+    is_expected.to contain_sysctl__value('fs.inotify.max_user_watches').with(
+      value: 1_048_576,
+      target: '/etc/sysctl.d/80-rke.conf',
+    )
+  end
+
+  it do
+    is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook').that_requires('Class[ipa]')
+  end
+end


### PR DESCRIPTION
This is foundational for the creation of an `rke2` role.