### PR TITLE
(common) add 139.229.181.0/27|vlan1801 to cpfde ipset

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -397,6 +397,7 @@ ipset::sets:
       - "139.229.175.128/25"  # vlan1502
       - "139.229.175.0/26"  # vlan1510
       - "139.229.175.64/26"  # vlan1511
+      - "139.229.181.0/27"  # vlan1801
 
 # sssd ipa client setup -- do not use on ipa servers
 sssd::main_config:

--- a/spec/support/spec/ipset.rb
+++ b/spec/support/spec/ipset.rb
@@ -81,6 +81,7 @@ shared_examples 'ipset' do
         139.229.175.128/25
         139.229.175.0/26
         139.229.175.64/26
+        139.229.181.0/27
       ],
     ).that_comes_before('Class[firewall]')
   end


### PR DESCRIPTION
This is needed to allow elqui nodes to contact tang.