### PR TITLE
(role/daq-mgt) Update DAQ to R5-V10.1

### DIFF
--- a/hieradata/node/auxtel-daq-mgt.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-daq-mgt.cp.lsst.org.yaml
@@ -4,8 +4,6 @@ profile::daq::daq_interface::uuid: "9129970c-d4b9-4602-82be-da776c06c064"
 profile::daq::daq_interface::was: "p3p1"
 profile::daq::daq_interface::mode: "dhcp-server"
 
-#daq::daqsdk::version: "R5-V6.7"
-
 network::interfaces_hash:
   em1:  # fqdn
     bootproto: "dhcp"

--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V8.2"
+daq::daqsdk::version: "R5-V10.1"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients

--- a/hieradata/site/tu/role/daq-mgt.yaml
+++ b/hieradata/site/tu/role/daq-mgt.yaml
@@ -2,5 +2,3 @@
 dhcp::dnsdomain: []  # ignore site value & mod default
 dhcp::nameservers: ~  # ignore site value
 dhcp::ntpservers: ~  # ignore site value
-
-#daq::daqsdk::version: "R5-V6.7"

--- a/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-daq-mgt-cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'auxtel-daq-mgt.cp.lsst.org', :sitepp do
       include_examples 'lsst-daq dhcp-server'
       include_examples 'daq nfs exports'
 
-      it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V8.2') }
+      it { is_expected.to contain_class('daq::daqsdk') }
       it { is_expected.to contain_class('daq::rptsdk').with_version('V3.5.3') }
       it { is_expected.to contain_host('auxtel-sm').with_ip('192.168.101.2') }
       it { is_expected.to contain_network__interface('p3p1').with_ensure('absent') }

--- a/spec/hosts/roles/atsdaq_spec.rb
+++ b/spec/hosts/roles/atsdaq_spec.rb
@@ -28,8 +28,6 @@ describe "#{role} role" do
           include_examples 'common', os_facts: os_facts, site: site
           include_examples 'ccs common', os_facts: os_facts
           include_examples 'lsst-daq sysctls'
-          # it { is_expected.to contain_class('ccs_daq') }
-          # it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V0.6') }
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
I'd like to stage DAQ R5-V10.1 to all the DAQ management servers in preparation for deploying it. 

I also removed a couple of places where the version had been commented out, and following the pattern for another spec file, removed the explicit version check.