### PR TITLE
(role/daq-mgt) Update DAQ to R5-V10.2

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V10.1"
+daq::daqsdk::version: "R5-V10.2"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients


### PR DESCRIPTION
Well, that didn't take long. V10.2 is here with the ability to configure which sensors are configured in Guide mode when there are more than 4 (i.e. Science Rafts.)