### PR TITLE
(cluster/{comcam,lsstcam}-ccs) add java17 settings for sal

### DIFF
--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -46,10 +46,12 @@ ccs_site: "summit"
 ccs_instrument: "comcam"
 
 ccs_daq::instrument: "%{lookup('ccs_instrument')}"
-
+ccs_sal::instrument: "%{lookup('ccs_instrument')}"
 ccs_sal::dds_domain: "%{lookup('ccs_site')}"
 ccs_sal::dds_interface: "comcam-mcm-dds"
-ccs_sal::instrument: "%{lookup('ccs_instrument')}"
+## Java 17
+ccs_sal::dds_extra: "export LD_PRELOAD=${JAVA_HOME}/lib/libjsig.so"
+ccs_sal::java_home: "/usr/lib/jvm/zulu-17"
 
 ccs_software::global_properties:
   - "org.lsst.ccs.lockservice=remote"

--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -37,9 +37,12 @@ ccs_instrument: "camera"
 ccs_daq::instrument: "%{lookup('ccs_instrument')}"
 ccs_daq::apps_noinstrument: true
 
+ccs_sal::instrument: "%{lookup('ccs_instrument')}"
 ccs_sal::dds_domain: "%{lookup('ccs_site')}"
 ccs_sal::dds_interface: "lsstcam-mcm-dds"
-ccs_sal::instrument: "%{lookup('ccs_instrument')}"
+## Java 17
+ccs_sal::dds_extra: "export LD_PRELOAD=${JAVA_HOME}/lib/libjsig.so"
+ccs_sal::java_home: "/usr/lib/jvm/zulu-17"
 
 ccs_software::global_properties:
   - "org.lsst.ccs.lockservice=remote"

--- a/hieradata/site/tu/cluster/comcam-ccs.yaml
+++ b/hieradata/site/tu/cluster/comcam-ccs.yaml
@@ -1,9 +1,6 @@
 ---
 ccs_site: "tucson"
 ccs_sal::dds_interface: "comcam-mcm-dds.tu.lsst.org"
-## Java 17:
-ccs_sal::java_home: "/usr/lib/jvm/zulu-17"
-ccs_sal::dds_extra: "export LD_PRELOAD=${JAVA_HOME}/lib/libjsig.so"
 
 ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
 


### PR DESCRIPTION
Specifically, set dds_extra and java_home.
This replaces existing tu-specific comcam settings.