### PR TITLE
(profile::ccs::file_transfer) do not install idna_ssl on rhel9+

### DIFF
--- a/site/profile/manifests/ccs/file_transfer.pp
+++ b/site/profile/manifests/ccs/file_transfer.pp
@@ -83,12 +83,14 @@ class profile::ccs::file_transfer (
           'multidict',
           'typing_extensions',
           'yarl',
+          'idna_ssl',
         ]
         $yum_extra_packages = []
       }
       '8': {
         $pip_extra_packages = [
           'aiosignal',
+          'idna_ssl',
         ]
         $yum_extra_packages = [
           'python3-async-timeout',
@@ -120,7 +122,6 @@ class profile::ccs::file_transfer (
     ]
 
     $pip_packages = $pip_extra_packages + [
-      'idna_ssl',
       'aiobotocore',
     ]
 


### PR DESCRIPTION
It is only required on older OS. On rhel9+ it just creates noise via pip mentioning that the requirements are already met.

Refs:
https://lsstc.slack.com/archives/C01270EHCQ3/p1722345845991169 https://github.com/voxpupuli/puppet-python/issues/626 https://github.com/aio-libs/idna-ssl/issues/8