### PR TITLE
(spec) drop EL7 from default list of tested platforms

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,12 +8,6 @@
   "dependencies": [],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",


### PR DESCRIPTION
This reduces the time to run the rake checks workflow by ~1/3.