### PR TITLE
(Puppetfile) bump puppet/firewalld to 5.0.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -45,7 +45,7 @@ mod 'puppet/chrony', '3.0.0'
 mod 'puppet/cron', '4.2.0'
 mod 'puppet/epel', '5.0.0'
 mod 'puppet/extlib', '7.2.0'
-mod 'puppet/firewalld', git: 'https://github.com/voxpupuli/puppet-firewalld', ref: '1eb95e1'  # stdlib 9.x
+mod 'puppet/firewalld', '5.0.0'
 mod 'puppet/hosts', '0.1.0'
 mod 'puppet/ipset', '4.2.0'
 mod 'puppet/kmod', '4.0.1'


### PR DESCRIPTION
The 5.0.0 release allows stdlib 9.x.