### PR TITLE
(role/rke) bump DEV client to v1.5.12

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::rke::version: "1.5.12"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -37,9 +37,9 @@ class profile::core::rke (
   }
 
   $rke_checksum = $version ? {
-    '1.5.8'      => 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
     '1.5.9'      => '1d31248135c2d0ef0c3606313d80bd27a199b98567a053036b9e49e13827f54b',
     '1.5.10'     => 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+    '1.5.12'     => 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -68,25 +68,6 @@ describe 'profile::core::rke' do
       end
 
       context 'with version param' do
-        context 'when 1.5.8' do
-          let(:params) do
-            {
-              version: '1.5.8',
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          include_examples 'rke profile'
-
-          it do
-            is_expected.to contain_class('rke').with(
-              version: '1.5.8',
-              checksum: 'f691a33b59db48485e819d89773f2d634e347e9197f4bb6b03270b192bd9786d',
-            )
-          end
-        end
-
         context 'when 1.5.9' do
           let(:params) do
             {
@@ -121,6 +102,25 @@ describe 'profile::core::rke' do
             is_expected.to contain_class('rke').with(
               version: '1.5.10',
               checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+            )
+          end
+        end
+
+        context 'when 1.5.12' do
+          let(:params) do
+            {
+              version: '1.5.12',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
+
+          it do
+            is_expected.to contain_class('rke').with(
+              version: '1.5.12',
+              checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
             )
           end
         end

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'ayekan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'namkueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
@@ -32,7 +32,7 @@ describe 'rancher01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -52,7 +52,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -43,11 +43,21 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  it do
-    is_expected.to contain_class('rke').with(
-      version: '1.5.10',
-      checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
-    )
+  case site
+  when 'dev'
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.5.12',
+        checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.5.10',
+        checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+      )
+    end
   end
 end
 


### PR DESCRIPTION
bumping rke client version on dev to 1.5.12 to use k8s v1.28.12
[](https://github.com/rancher/rke/releases/tag/v1.5.12)

note: the releases no longer have the sha256 file of the binaries