### PR TITLE
(node/lsstcam-ccobwb.cp) fix duplicate uuid in nm::connections

### DIFF
--- a/hieradata/node/lsstcam-ccobwb.cp.lsst.org.yaml
+++ b/hieradata/node/lsstcam-ccobwb.cp.lsst.org.yaml
@@ -34,7 +34,7 @@ nm::connections:
     content:
       connection:
         id: "enp7s0"
-        uuid: "da97db8e-6400-4cca-9334-71995eb2ac1d"
+        uuid: "c01f2d80-ac3c-403b-b4e7-21504932d42f"
         type: "ethernet"
         interface-name: "enp7s0"
       ethernet: {}


### PR DESCRIPTION
Note multiple hosts appear to have this issue - see https://rubinobs.atlassian.net/browse/IT-5581