### PR TITLE
(site/cp/cluster/comcam-ccs) enable mrtg

### DIFF
--- a/hieradata/site/cp/cluster/comcam-ccs.yaml
+++ b/hieradata/site/cp/cluster/comcam-ccs.yaml
@@ -1,0 +1,2 @@
+---
+profile::ccs::monitoring::mrtg: true


### PR DESCRIPTION
Camera team in Chile has requested mrtg monitoring also be enabled for comcam (was previously done for lsstcam in pull #1395 .