### PR TITLE
(role/rke) bump LS client to v1.5.12

### DIFF
--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.5.12"

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -50,7 +50,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
@@ -44,7 +44,7 @@ describe 'chango01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
-          checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+          version: '1.5.12',
+          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
         )
       end
 

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'konkong01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
-          checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+          version: '1.5.12',
+          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
         )
       end
 

--- a/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'luan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
-          checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+          version: '1.5.12',
+          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
         )
       end
 

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'manke01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.10',
-          checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
+          version: '1.5.12',
+          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
         )
       end
 

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -32,7 +32,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.10',
+          version: '1.5.12',
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -44,7 +44,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   end
 
   case site
-  when 'dev', 'tu'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke').with(
         version: '1.5.12',


### PR DESCRIPTION
bumping the RKE client to version 1.5.12 for k8s v1.28.12