### PR TITLE
(cluster/lsstcam-ccs) send rsyslog to fluentbit ayekan

### DIFF
--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -1,4 +1,18 @@
 ---
+rsyslog::feature_packages:
+  - "rsyslog-openssl"
+rsyslog::config::actions:
+  fluentbit_dev:
+    type: "omfwd"
+    facility: "*.*"
+    config:
+      target: "rsyslog.fluent.ayekan.dev.lsst.org"
+      port: 5140
+      protocol: "tcp"
+      StreamDriver: "ossl"
+      StreamDriverMode: "1"
+      StreamDriverAuthMode: "anon"
+
 postfix::manage_root_alias: false
 postfix::inet_protocols: "ipv4"
 postfix::inet_interfaces: "localhost"

--- a/spec/hosts/nodes/lsstcam-dc01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.cp.lsst.org_spec.rb
@@ -27,6 +27,8 @@ describe 'lsstcam-dc01.cp.lsst.org', :sitepp do
         }
       end
 
+      include_examples 'lsstcam-rsyslog'
+
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'baremetal'

--- a/spec/support/spec/lsstcam-rsyslog.rb
+++ b/spec/support/spec/lsstcam-rsyslog.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+shared_examples 'lsstcam-rsyslog' do
+  it { is_expected.to contain_package('rsyslog-openssl') }
+
+  it do
+    is_expected.to contain_rsyslog__component__action('fluentbit_dev').with(
+      type: 'omfwd',
+      facility: '*.*',
+      config: {
+        'target' => 'rsyslog.fluent.ayekan.dev.lsst.org',
+        'port' => '5140',
+        'protocol' => 'tcp',
+        'StreamDriver' => 'ossl',
+        'StreamDriverMode' => '1',
+        'StreamDriverAuthMode' => 'anon',
+      },
+    )
+  end
+end


### PR DESCRIPTION
As requested, we need to send the rsyslogs to the dev instance of Fluentbit so the logs can reach OpenSearch, this is a temporary fix while the monitoring system is properly set at the Summit and all hosts change the endpoint to a deployment made for production.
I created a support spec for this in case we need to modify all the tests for the lsstcam-ccs cluster hierarchy. (even tho, it's temporary) 