### PR TITLE
(cluster/*) set ceph cluster tuned profile to latency-performance

### DIFF
--- a/hieradata/cluster/antu.yaml
+++ b/hieradata/cluster/antu.yaml
@@ -3,7 +3,7 @@ clustershell::groupmembers:
   antu:
     group: "antu"
     member: "antu[01-04]"
-
+tuned::active_profile: "latency-performance"
 nm::connections:
   enp65s0f0.2130:
     content:

--- a/hieradata/cluster/ayekan.yaml
+++ b/hieradata/cluster/ayekan.yaml
@@ -1,6 +1,7 @@
 ---
 clustershell::groupmembers:
   ayekan: {group: "ayekan", member: "ayekan[01-03]"}
+tuned::active_profile: "latency-performance"
 nm::connections:
   eno1np0:
     content: |

--- a/hieradata/cluster/chonchon.yaml
+++ b/hieradata/cluster/chonchon.yaml
@@ -2,6 +2,7 @@
 clustershell::groupmembers:
   chonchon: {group: "chonchon", member: "chonchon[01-05]"}
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   br1800:
     content:

--- a/hieradata/cluster/elqui.yaml
+++ b/hieradata/cluster/elqui.yaml
@@ -3,6 +3,7 @@ clustershell::groupmembers:
   elqui:
     group: "elqui"
     member: "elqui[01-18]"
+tuned::active_profile: "latency-performance"
 nm::conf:
   device:
     keep-configuration: "no"

--- a/hieradata/cluster/gaw.yaml
+++ b/hieradata/cluster/gaw.yaml
@@ -1,3 +1,4 @@
 ---
 clustershell::groupmembers:
   gaw: {group: "gaw", member: "gaw[01-05]"}
+tuned::active_profile: "latency-performance"

--- a/hieradata/cluster/konkong.yaml
+++ b/hieradata/cluster/konkong.yaml
@@ -3,6 +3,7 @@ clustershell::groupmembers:
   konkong: {group: "konkong", member: "konkong[01-03]"}
 profile::core::ospl::enable_rundir: true
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   eno1np0:
     content: |

--- a/hieradata/cluster/kueyen.yaml
+++ b/hieradata/cluster/kueyen.yaml
@@ -3,6 +3,7 @@ clustershell::groupmembers:
   kueyen: {group: "kueyen", member: "kueyen[01-03]"}
 profile::core::ospl::enable_rundir: true
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   em1:  #PXE Boot
     content: |

--- a/hieradata/cluster/luan.yaml
+++ b/hieradata/cluster/luan.yaml
@@ -1,3 +1,4 @@
 ---
 clustershell::groupmembers:
   luan: {group: "luan", member: "luan[01-05]"}
+tuned::active_profile: "latency-performance"

--- a/hieradata/cluster/lukay.yaml
+++ b/hieradata/cluster/lukay.yaml
@@ -1,3 +1,4 @@
 ---
 clustershell::groupmembers:
   lukay: {group: "lukay", member: "lukay[01-04]"}
+tuned::active_profile: "latency-performance"

--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -5,6 +5,7 @@ clustershell::groupmembers:
     member: "manke[01-10]"
 profile::core::ospl::enable_rundir: true
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   eno1np0:
     content:

--- a/hieradata/cluster/namkueyen.yaml
+++ b/hieradata/cluster/namkueyen.yaml
@@ -1,6 +1,7 @@
 ---
 clustershell::groupmembers:
   namkueyen: {group: "namkueyen", member: "namkueyen[01-03]"}
+tuned::active_profile: "latency-performance"
 nm::connections:
   eno1:  #fqdn
     content: |

--- a/hieradata/cluster/pillan.yaml
+++ b/hieradata/cluster/pillan.yaml
@@ -3,6 +3,7 @@ clustershell::groupmembers:
   pillan: {group: "pillan", member: "pillan[01-09]"}
 profile::core::ospl::enable_rundir: true
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   enp4s0f3u2u2c2:
     content: |

--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -2,6 +2,7 @@
 clustershell::groupmembers:
   ruka: {group: "ruka", member: "ruka[01-05]"}
 profile::core::k8snode::enable_dhcp: true
+tuned::active_profile: "latency-performance"
 nm::connections:
   br2101:
     content:

--- a/hieradata/cluster/yagan.yaml
+++ b/hieradata/cluster/yagan.yaml
@@ -3,3 +3,4 @@ clustershell::groupmembers:
   yagan: {group: "yagan", member: "yagan[01-20]"}
 profile::core::k8snode::enable_dhcp: true
 profile::core::ospl::enable_rundir: true
+tuned::active_profile: "latency-performance"

--- a/hieradata/cluster/yepun.yaml
+++ b/hieradata/cluster/yepun.yaml
@@ -1,3 +1,4 @@
 ---
 clustershell::groupmembers:
   yepun: {group: "yepun", member: "yepun[01-05]"}
+tuned::active_profile: "latency-performance"

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it do

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -28,6 +28,7 @@ describe 'ayekan01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it { is_expected.to compile.with_all_deps }

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -32,6 +32,7 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/chonchon04.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon04.cp.lsst.org_spec.rb
@@ -32,6 +32,7 @@ describe 'chonchon04.cp.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/elqui01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/elqui01.cp.lsst.org_spec.rb
@@ -30,6 +30,7 @@ describe 'elqui01.cp.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         expect(catalogue.resource('class', 'rke2')[:config]).to include(

--- a/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
@@ -33,6 +33,7 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it do

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -30,6 +30,7 @@ describe 'konkong01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it do

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -30,6 +30,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
 
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
+      include_examples 'ceph cluster'
       include_context 'with nm interface'
 
       it do

--- a/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
@@ -33,6 +33,7 @@ describe 'luan01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it do

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -33,6 +33,7 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
+      include_examples 'ceph cluster'
       include_context 'with nm interface'
 
       it do

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -30,6 +30,7 @@ describe 'manke01.ls.lsst.org', :sitepp do
 
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
       include_examples 'docker', docker_version: '24.0.9'
 
       it do

--- a/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'namkueyen01.dev.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -31,6 +31,7 @@ describe 'pillan01.tu.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -34,6 +34,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/ruka01.dev.lsst.org-rke2_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org-rke2_spec.rb
@@ -33,6 +33,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'baremetal'
+      include_examples 'ceph cluster'
 
       it do
         expect(catalogue.resource('class', 'rke2')[:config]).to include(

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -34,6 +34,7 @@ describe 'ruka01.dev.lsst.org', :sitepp do
 
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
@@ -34,6 +34,7 @@ describe 'ruka04.dev.lsst.org', :sitepp do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'baremetal'
+      include_examples 'ceph cluster'
 
       include_context 'with nm interface'
 

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -33,6 +33,7 @@ describe 'yagan01.cp.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -34,6 +34,7 @@ describe 'yepun01.cp.lsst.org', :sitepp do
       include_examples 'docker', docker_version: '24.0.9'
       include_examples 'baremetal'
       include_context 'with nm interface'
+      include_examples 'ceph cluster'
 
       it do
         is_expected.to contain_class('clustershell').with(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -910,8 +910,6 @@ shared_examples 'baremetal' do |bmc: nil|
   it do
     if node_params[:role] == 'hypervisor'
       is_expected.to contain_class('tuned').with_active_profile('virtual-host')
-    else
-      is_expected.to contain_class('tuned').with_active_profile('balanced')
     end
   end
 

--- a/spec/support/spec/ceph.rb
+++ b/spec/support/spec/ceph.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+shared_examples 'ceph cluster' do
+  it do
+    is_expected.to contain_class('tuned').with(
+      active_profile: 'latency-performance',
+    )
+  end
+end


### PR DESCRIPTION
It was mentioned in a Ceph Days talk that this may improve the consistentcy of ceph benchmarks.