### PR TITLE
(common) disable pquota by default

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -572,3 +572,5 @@ rke2::config:
   disable:
     - "rke2-ingress-nginx"
   disable-cloud-controller: true
+
+profile::core::kernel::pquota::ensure: "absent"  # temporary until profile::core::kernel::pquota profile is removed from roles which don't need it

--- a/site/profile/manifests/core/kernel/pquota.pp
+++ b/site/profile/manifests/core/kernel/pquota.pp
@@ -10,5 +10,6 @@ class profile::core::kernel::pquota (
 ) {
   profile::util::kernel_param { 'rootflags=pquota':
     ensure => $ensure,
+    reboot => false,
   }
 }

--- a/site/profile/manifests/core/kernel/pquota.pp
+++ b/site/profile/manifests/core/kernel/pquota.pp
@@ -1,3 +1,14 @@
-class profile::core::kernel::pquota {
-  profile::util::kernel_param { 'rootflags=pquota': }
+# @summary
+#   Enable pquota on the root filesystem. Only applicable when the root
+#   filesystm is XFS.
+#
+# @param ensure
+#   Whether the kernel parameter should be present or absent.
+#
+class profile::core::kernel::pquota (
+  Enum['present', 'absent'] $ensure = 'present',
+) {
+  profile::util::kernel_param { 'rootflags=pquota':
+    ensure => $ensure,
+  }
 }

--- a/site/profile/manifests/util/kernel_param.pp
+++ b/site/profile/manifests/util/kernel_param.pp
@@ -8,13 +8,18 @@
 #   Whether or not to force a reboot to ensure kernel parameter is set on the running kernel.
 #   Defaults to `true`.
 #
+# @param ensure
+#   Whether the kernel parameter should be present or absent.
+#   Defaults to `preset`.
+#
 define profile::util::kernel_param (
   Boolean $reboot = true,
+  Enum['present', 'absent'] $ensure = 'present',
 ) {
-  $message = "set kernel parameter: ${name}"
+  $message = "set kernel parameter: ${name} to ${ensure}"
 
   grubby::kernel_opt { $name:
-    ensure => present,
+    ensure => $ensure,
     scope  => 'ALL',
   }
 

--- a/spec/defines/util/kernel_param_spec.rb
+++ b/spec/defines/util/kernel_param_spec.rb
@@ -21,7 +21,7 @@ describe 'profile::util::kernel_param' do
         it do
           is_expected.to contain_reboot(title).with(
             apply: 'finished',
-            message: "set kernel parameter: #{title}",
+            message: "set kernel parameter: #{title} to present",
             when: 'refreshed',
           )
         end
@@ -43,7 +43,7 @@ describe 'profile::util::kernel_param' do
         it do
           is_expected.to contain_reboot(title).with(
             apply: 'finished',
-            message: "set kernel parameter: #{title}",
+            message: "set kernel parameter: #{title} to present",
             when: 'refreshed',
           )
         end
@@ -63,6 +63,26 @@ describe 'profile::util::kernel_param' do
         end
 
         it { is_expected.not_to contain_reboot(title) }
+      end
+
+      context 'with ensure => present' do
+        let(:params) { { ensure: 'present' } }
+
+        it do
+          is_expected.to contain_grubby__kernel_opt(title).with(
+            ensure: 'present',
+          )
+        end
+      end
+
+      context 'with ensure => absent' do
+        let(:params) { { ensure: 'present' } }
+
+        it do
+          is_expected.to contain_grubby__kernel_opt(title).with(
+            ensure: 'absent',
+          )
+        end
       end
     end
   end

--- a/spec/defines/util/kernel_param_spec.rb
+++ b/spec/defines/util/kernel_param_spec.rb
@@ -76,7 +76,7 @@ describe 'profile::util::kernel_param' do
       end
 
       context 'with ensure => absent' do
-        let(:params) { { ensure: 'present' } }
+        let(:params) { { ensure: 'absent' } }
 
         it do
           is_expected.to contain_grubby__kernel_opt(title).with(

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -50,6 +50,12 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
       forget_flags: '--keep-last 20',
     )
   end
+
+  it do
+    is_expected.to contain_grubby__kernel_opt('rootflags=pquota').with(
+      ensure: 'absent',
+    )
+  end
 end
 
 role = 'rke2agent'

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -64,6 +64,12 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
       forget_flags: '--keep-last 20',
     )
   end
+
+  it do
+    is_expected.to contain_grubby__kernel_opt('rootflags=pquota').with(
+      ensure: 'absent',
+    )
+  end
 end
 
 role = 'rke2server'

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -49,6 +49,12 @@ shared_examples 'generic rke' do |os_facts:, site:|
       checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
     )
   end
+
+  it do
+    is_expected.to contain_grubby__kernel_opt('rootflags=pquota').with(
+      ensure: 'absent',
+    )
+  end
 end
 
 role = 'rke'


### PR DESCRIPTION
This cmdline flag only applies to xfs.  It seems that pquota isn’t enabled
on /var/lib/docker on most (any?) k8s nodes, so it should be safe to remove
puppet enforcement on this cmdline flag.

This will only apply to the rke, rke2server, and rke2agent roles which
include profile::core::kernel::quota.  Once this flag has been removed
from cmdline on all nodes, this commit may be reverted and the ::pquota
profile removed from the listed roles.