### PR TITLE
(role/daq-mgt) Update DAQ to R5-V10.8

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V10.2"
+daq::daqsdk::version: "R5-V10.8"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients


### PR DESCRIPTION
This is needed for Guider testing on the Camera at the summit.