### PR TITLE
(role/ccs-dc) add hosts entry for SLAC s3

### DIFF
--- a/hieradata/role/ccs-dc.yaml
+++ b/hieradata/role/ccs-dc.yaml
@@ -10,3 +10,7 @@ classes:
   - "profile::core::sysctl::lhn"
 
 profile::ccs::common::sysctls: false
+
+hosts::entries:
+  sdfembs3.sdf.slac.stanford.edu:
+    ip: "172.24.7.249"

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -39,6 +39,7 @@ describe "#{role} role" do
           ].each do |cls|
             it { is_expected.to contain_class(cls) }
           end
+          it { is_expected.to contain_host('sdfembs3.sdf.slac.stanford.edu').with_ip('172.24.7.249') }
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
same as the `comcam-fp01`

add entry on `/etc/hosts` for the SLAC s3 entry point
