### PR TITLE
(Puppetfile) switch from camptocamp/augeas to puppet/augeas 2.0.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,6 @@ forge 'https://forgeapi.puppetlabs.com'
 mod 'atsonkov/grubby', '0.3.2'
 mod 'blockops/tailscale', git: 'https://github.com/lsst-it/puppet-tailscale', ref: '6334c25'  # https://gitlab.com/blockops/puppet-tailscale/-/merge_requests/6
 mod 'bodgit/scl', git: 'https://github.com/lsst-it/puppet-scl', ref: 'c367361'  # https://github.com/bodgit/puppet-scl/pull/2
-mod 'camptocamp/augeas', '1.9.0'
 mod 'ccin2p3/etc_services', git: 'https://github.com/lsst-it/puppet-etc_services', ref: 'ff17b73' # https://github.com/ccin2p3/puppet-etc_services/pull/11
 mod 'ccin2p3/mit_krb5', git: 'https://github.com/lsst-it/puppet-mit_krb5.git', ref: 'f8f0242'  # https://github.com/ccin2p3/puppet-mit_krb5/pull/29 https://github.com/ccin2p3/puppet-mit_krb5/pull/34 https://github.com/ccin2p3/puppet-mit_krb5/pull/35
 mod 'cirrax/libvirt', '5.0.4'
@@ -38,6 +37,7 @@ mod 'lsst/rke2', '2.0.0'
 mod 'lsst/smee', '2.3.0'
 mod 'puppet/alternatives', '5.1.0'
 mod 'puppet/archive', '7.1.0'
+mod 'puppet/augeas', '2.0.0'
 mod 'puppet/augeasproviders_apache', '5.0.0'
 mod 'puppet/augeasproviders_core', '4.1.0'
 mod 'puppet/augeasproviders_grub', '5.1.2'


### PR DESCRIPTION
At long last, `camptocamp/augeas` has been migrated to voxpupuli.