### PR TITLE
(profile::archive::common) rm unused services, accounts, & packages

### DIFF
--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -234,12 +234,6 @@ profile::archive::common::packages:
   - "gcc-c++"
   - "git"
 
-profile::archive::common::group_list:
-  # this is duplicating the ipa gid as a local group
-  &docker_name docker-%{facts.hostname}:
-    ensure: "present"
-    gid: 70014
-    forcelocal: true
 profile::archive::common::user_list:
   arc:
     uid: 61000
@@ -253,8 +247,6 @@ profile::archive::common::user_list:
     managehome: true
     system: false
     managevim: false
-    groups:
-      - *docker_name
 
 profile::core::dtn::sysctls:
   net.core.rmem_max:

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -229,25 +229,6 @@ profile::archive::data::comcam::files:
     owner: &saluser 73006
     group: *saluser
 
-profile::archive::common::packages:
-  - "cmake"
-  - "gcc-c++"
-  - "git"
-
-profile::archive::common::user_list:
-  arc:
-    uid: 61000
-    gid: 61000
-    managehome: true
-    system: false
-    managevim: false
-  atadbot:
-    uid: 61002
-    gid: 61002
-    managehome: true
-    system: false
-    managevim: false
-
 profile::core::dtn::sysctls:
   net.core.rmem_max:
     value: 2147483647

--- a/site/profile/manifests/archive/common.pp
+++ b/site/profile/manifests/archive/common.pp
@@ -22,8 +22,6 @@ class profile::archive::common (
   include profile::archive::data
   include profile::core::common
   include profile::core::debugutils
-  include profile::core::docker
-  include profile::core::docker::prune
   include profile::core::nfsclient
   include profile::core::nfsserver
 

--- a/site/profile/manifests/archive/common.pp
+++ b/site/profile/manifests/archive/common.pp
@@ -1,43 +1,10 @@
 # @summary
 #   Common archiver functionality.
 #
-# @param packages
-#   List of packages to install.
-#
-# @param python_pips
-#   python pips to install.
-#
-# @param user_list
-#   List of local unix users to create.
-#
-# @param group_list
-#   List of local unix groups  to create.
-#
-class profile::archive::common (
-  Optional[Array[String]]     $packages = undef,
-  Optional[Hash[String,Hash]] $python_pips = undef,
-  Optional[Hash[String,Hash]] $user_list = undef,
-  Optional[Hash[String,Hash]] $group_list = undef,
-) {
+class profile::archive::common {
   include profile::archive::data
   include profile::core::common
   include profile::core::debugutils
   include profile::core::nfsclient
   include profile::core::nfsserver
-
-  if $packages {
-    ensure_packages($packages)
-  }
-
-  if $user_list {
-    ensure_resources('accounts::user', $user_list)
-  }
-
-  if $group_list {
-    ensure_resources('group', $group_list)
-  }
-
-  sudo::conf { 'comcam_archive_cmd':
-    content => '%comcam-archive-sudo ALL=(arc,atadbot) NOPASSWD: ALL',
-  }
 }

--- a/spec/classes/archive/commmon_spec.rb
+++ b/spec/classes/archive/commmon_spec.rb
@@ -16,22 +16,6 @@ describe 'profile::archive::common' do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'archiver'
-
-      %w[
-        git
-        cmake
-        gcc-c++
-      ].each do |p|
-        it { is_expected.to contain_package(p) }
-      end
-
-      it { is_expected.to contain_accounts__user('arc').with_uid('61000') }
-      it { is_expected.to contain_accounts__user('atadbot').with_uid('61002') }
-
-      it do
-        is_expected.to contain_sudo__conf('comcam_archive_cmd')
-          .with_content('%comcam-archive-sudo ALL=(arc,atadbot) NOPASSWD: ALL')
-      end
     end
   end
 end

--- a/spec/classes/archive/commmon_spec.rb
+++ b/spec/classes/archive/commmon_spec.rb
@@ -21,14 +21,12 @@ describe 'profile::archive::common' do
         git
         cmake
         gcc-c++
-        docker-compose-plugin
       ].each do |p|
         it { is_expected.to contain_package(p) }
       end
 
       it { is_expected.to contain_accounts__user('arc').with_uid('61000') }
       it { is_expected.to contain_accounts__user('atadbot').with_uid('61002') }
-      it { is_expected.to contain_group('docker-foo').with_gid('70014') }
 
       it do
         is_expected.to contain_sudo__conf('comcam_archive_cmd')

--- a/spec/hosts/roles/auxtel_archiver_spec.rb
+++ b/spec/hosts/roles/auxtel_archiver_spec.rb
@@ -26,7 +26,6 @@ describe "#{role} role" do
 
           include_examples 'common', os_facts: os_facts, site: site
           include_examples 'archiver'
-          include_examples 'docker'
           include_examples 'archive data auxtel'
 
           it { is_expected.to contain_file('/data/repo/LATISS') }

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -26,7 +26,6 @@ describe "#{role} role" do
 
           include_examples 'common', os_facts: os_facts, site: site
           include_examples 'archiver'
-          include_examples 'docker'
 
           it { is_expected.to contain_file('/data/repo/LSSTComCam') }
         end # host

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -479,20 +479,6 @@ shared_examples 'lhn sysctls', :lhn_node do
   end
 end
 
-shared_examples 'archiver', :archiver do
-  %w[
-    profile::archive::data
-    profile::core::common
-    profile::core::debugutils
-    profile::core::docker
-    profile::core::docker::prune
-    profile::core::nfsclient
-    profile::core::nfsserver
-  ].each do |c|
-    it { is_expected.to contain_class(c) }
-  end
-end
-
 shared_examples 'lsst-daq sysctls' do
   it do
     is_expected.to contain_sysctl__value('net.core.rmem_max')
@@ -830,21 +816,6 @@ shared_examples 'x2go packages' do |os_facts:|
       group: 'root',
       mode: '0440',
     ).that_requires('Package[x2goserver]')
-  end
-end
-
-shared_examples 'archive data auxtel' do
-  it { is_expected.to contain_file('/data/repo/LATISS').with_mode('0777') }
-  it { is_expected.to contain_file('/data/repo/LATISS/u').with_mode('1777') }
-  it { is_expected.not_to contain_file('/data/repo/LSSTComCam') }
-
-  it do
-    is_expected.to contain_file('/data/allsky').with(
-      ensure: 'directory',
-      mode: '0755',
-      owner: 1000,
-      group: 983,
-    )
   end
 end
 

--- a/spec/support/spec/archiver.rb
+++ b/spec/support/spec/archiver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# this is an anti-pattern, do not test for inclusion of profile classes in a role
+shared_examples 'archiver', :archiver do
+  %w[
+    profile::archive::data
+    profile::core::common
+    profile::core::debugutils
+    profile::core::nfsclient
+    profile::core::nfsserver
+  ].each do |c|
+    it { is_expected.to contain_class(c) }
+  end
+end
+
+shared_examples 'archive data auxtel' do
+  it { is_expected.to contain_file('/data/repo/LATISS').with_mode('0777') }
+  it { is_expected.to contain_file('/data/repo/LATISS/u').with_mode('1777') }
+  it { is_expected.not_to contain_file('/data/repo/LSSTComCam') }
+
+  it do
+    is_expected.to contain_file('/data/allsky').with(
+      ensure: 'directory',
+      mode: '0755',
+      owner: 1000,
+      group: 983,
+    )
+  end
+end


### PR DESCRIPTION
The {comcam,auxtel}-archiver roles serve only as NFS servers (which should be retired before the start of operations).

This unused code was noticed while remove the usage of legacy facts in another feature branch.