### PR TITLE
(role/htcondor) fix comcam-archiver NFS to nfs3.cp

### DIFF
--- a/hieradata/site/cp/role/htcondor.yaml
+++ b/hieradata/site/cp/role/htcondor.yaml
@@ -16,16 +16,16 @@ nfs::client_mounts:
     server: "nfs-auxtel.cp.lsst.org"
     atboot: true
   /repo/LSSTComCam:
-    share: "/repo/LSSTComCam"
-    server: "comcam-archiver.cp.lsst.org"
+    share: "/comcam/repo/LSSTComCam"
+    server: "nfs3.cp.lsst.org"
     atboot: true
   /readonly/lsstdata/other:
     share: "lsstdata"
     server: "nfs1.cp.lsst.org"
     atboot: true
   /readonly/lsstdata/comcam:
-    share: "lsstdata"
-    server: "comcam-archiver.cp.lsst.org"
+    share: "/comcam/lsstdata"
+    server: "nfs3.cp.lsst.org"
     atboot: true
   /readonly/lsstdata/auxtel:
     share: "/auxtel/lsstdata"

--- a/spec/hosts/roles/htcondor_spec.rb
+++ b/spec/hosts/roles/htcondor_spec.rb
@@ -143,8 +143,8 @@ describe "#{role} role" do
 
             it do
               is_expected.to contain_nfs__client__mount('/repo/LSSTComCam').with(
-                share: '/repo/LSSTComCam',
-                server: 'comcam-archiver.cp.lsst.org',
+                share: '/comcam/repo/LSSTComCam',
+                server: 'nfs3.cp.lsst.org',
                 atboot: true
               )
             end
@@ -159,8 +159,8 @@ describe "#{role} role" do
 
             it do
               is_expected.to contain_nfs__client__mount('/readonly/lsstdata/comcam').with(
-                share: 'lsstdata',
-                server: 'comcam-archiver.cp.lsst.org',
+                share: '/comcam/lsstdata',
+                server: 'nfs3.cp.lsst.org',
                 atboot: true
               )
             end


### PR DESCRIPTION
on `IT-5692` it was decided to move the NFS from `comcam-archiver.cp` into the `nfs3.cp` this broke somethings including `HTCondor`
this goes great with https://github.com/lsst-it/k8s-cookbook/pull/610