### PR TITLE
(site/tu) bump rke to 1.6.2 for k8s rke v1.29.8

### DIFF
--- a/hieradata/site/tu/role/rke.yaml
+++ b/hieradata/site/tu/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.6.2"

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -38,7 +38,7 @@ describe 'pillan01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -41,7 +41,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -44,7 +44,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   end
 
   case site
-  when 'dev'
+  when 'dev', 'tu'
     it do
       is_expected.to contain_class('rke').with(
         version: '1.6.2',


### PR DESCRIPTION
October K8s Bump to `1.29.8` with rke client `1.6.2`
