### PR TITLE
(role/rke) bump LS client to v1.6.2

### DIFF
--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.6.2"

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -50,7 +50,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'chango01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'konkong01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'luan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'manke01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.5.12'
+          version: '1.6.2'
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -44,7 +44,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   end
 
   case site
-  when 'dev', 'tu'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke').with(
         version: '1.6.2',


### PR DESCRIPTION
this is October upgrade on the Base... `rke client` is bump to `v1.6.2` and `k8s` to `v1.29.8`

this PR goes incredible well with https://github.com/lsst-it/k8s-cookbook/pull/622