### PR TITLE
(cluster/{auxtel|comcam|lsstcam}-ccs) switch alerts to Rubin Slack

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -26,7 +26,7 @@ ccs_software::jdk8::package: "jdk1.8"
 ccs_software::jdk8::dir: "jdk1.8.0_202-amd64"
 ccs_software::jdk8::version: "2000:1.8.0_202-fcs"
 
-ccs_software::service_email: "auxtel-ccs-alerts-aaaadjkgtdl6pb2omvdi732xci@lsstc.slack.com"
+ccs_software::service_email: "auxtel-ccs-alerts-aaaaoikgy7stloxmg54kii7uwi@rubin-obs.slack.com"
 
 clustershell::groupmembers:
   misc: {group: "misc", member: "auxtel-mcm,auxtel-dc01,auxtel-fp01"}
@@ -34,7 +34,7 @@ clustershell::groupmembers:
   all: {group: "all", member: "@misc,@hcu"}
 
 ccs_monit::alert:
-  - "auxtel-ccs-alerts-aaaadjkgtdl6pb2omvdi732xci@lsstc.slack.com"
+  - "auxtel-ccs-alerts-aaaaoikgy7stloxmg54kii7uwi@rubin-obs.slack.com"
 
 java_artisanal::package: "jdk1.8"
 java_artisanal::dir: "jdk1.8.0_202-amd64"

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -61,11 +61,11 @@ ccs_software::global_properties:
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"
 
 ## comcam-alerts
-ccs_software::service_email: "x7z0x9c0t2k4r1n1@lsstc.slack.com"
+ccs_software::service_email: "comcam-alerts-aaaaoiphax6ggc2vzy5idxkmke@rubin-obs.slack.com"
 
 ccs_monit::alert:
   ## comcam-alerts
-  - "x7z0x9c0t2k4r1n1@lsstc.slack.com"
+  - "comcam-alerts-aaaaoiphax6ggc2vzy5idxkmke@rubin-obs.slack.com"
 
 ccs_mrtg::loss_host: "comcam-mcm"
 

--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -65,11 +65,11 @@ ccs_software::global_properties:
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"
 
 ## lsstcam-alerts
-ccs_software::service_email: "lsstcam-alerts-aaaah4qfu4lhjnjpl4wmbjyx2y@lsstc.slack.com"
+ccs_software::service_email: "lsstcam-alerts-aaaaoikijncrl3mtoosglrzsqm@rubin-obs.slack.com"
 
 ccs_monit::alert:
   ## lsstcam-alerts
-  - "lsstcam-alerts-aaaah4qfu4lhjnjpl4wmbjyx2y@lsstc.slack.com"
+  - "lsstcam-alerts-aaaaoikijncrl3mtoosglrzsqm@rubin-obs.slack.com"
 
 ccs_mrtg::loss_host: "lsstcam-mcm"
 

--- a/spec/hosts/nodes/lsstcam-db01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-db01.cp.lsst.org_spec.rb
@@ -25,7 +25,7 @@ describe 'lsstcam-db01.cp.lsst.org', :sitepp do
         }
       end
       let(:alert_email) do
-        'lsstcam-alerts-aaaah4qfu4lhjnjpl4wmbjyx2y@lsstc.slack.com'
+        'lsstcam-alerts-aaaaoikijncrl3mtoosglrzsqm@rubin-obs.slack.com'
       end
 
       it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
Note base- and tucson- teststand alerts remain on LSSTC Slack.