### PR TITLE
(role/rke) bump CP client to v1.6.2

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,2 +1,0 @@
----
-profile::core::rke::version: "1.6.2"

--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,3 +1,2 @@
 ---
 profile::core::docker::version: "24.0.9"
-profile::core::rke::version: "1.6.2"

--- a/hieradata/site/tu/role/rke.yaml
+++ b/hieradata/site/tu/role/rke.yaml
@@ -1,3 +1,2 @@
 ---
 profile::core::docker::version: "24.0.9"
-profile::core::rke::version: "1.6.2"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -9,7 +9,7 @@
 #
 class profile::core::rke (
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
-  String                         $version       = '1.5.12',
+  String                         $version       = '1.6.2',
 ) {
   include kmod
   require ipa

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -26,8 +26,8 @@ describe 'profile::core::rke' do
 
         it do
           is_expected.to contain_class('rke').with(
-            version: '1.5.12',
-            checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+            version: '1.6.2',
+            checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
           )
         end
       end

--- a/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon01.cp.lsst.org_spec.rb
@@ -50,8 +50,8 @@ describe 'chonchon01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/chonchon04.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chonchon04.cp.lsst.org_spec.rb
@@ -50,8 +50,8 @@ describe 'chonchon04.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.cp.lsst.org_spec.rb
@@ -31,8 +31,8 @@ describe 'rancher01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -51,8 +51,8 @@ describe 'yagan01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'yagan11.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.5.12',
-          checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
+          version: '1.6.2',
+          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
         )
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -43,21 +43,11 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  case site
-  when 'dev', 'tu', 'ls'
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.6.2',
-        checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
-      )
-    end
-  else
-    it do
-      is_expected.to contain_class('rke').with(
-        version: '1.5.12',
-        checksum: 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586'
-      )
-    end
+  it do
+    is_expected.to contain_class('rke').with(
+      version: '1.6.2',
+      checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+    )
   end
 
   it do


### PR DESCRIPTION
October Updates - rke client `v1.6.2` is default now to get all k8s cluster in `v1.29.8`
this goes great with PR https://github.com/lsst-it/k8s-cookbook/pull/631