### PR TITLE
(common/rke2) bump rke2 to v1.29.9 global

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -566,8 +566,8 @@ restic::host: "s3.us-east-1.amazonaws.com"
 pi::config::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete
 pi::cmdline::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete
 
-rke2::release_series: "1.28"
-rke2::version: "1.28.12~rke2r1"
+rke2::release_series: "1.29"
+rke2::version: "1.29.9~rke2r1"
 rke2::versionlock: true
 rke2::config:
   server: "https://%{::cluster}.%{::site}.lsst.org:9345"

--- a/hieradata/site/dev/role/rke2agent.yaml
+++ b/hieradata/site/dev/role/rke2agent.yaml
@@ -1,3 +1,0 @@
----
-rke2::release_series: "1.29"
-rke2::version: "1.29.9~rke2r1"

--- a/hieradata/site/dev/role/rke2server.yaml
+++ b/hieradata/site/dev/role/rke2server.yaml
@@ -1,3 +1,0 @@
----
-rke2::release_series: "1.29"
-rke2::version: "1.29.9~rke2r1"

--- a/spec/hosts/nodes/elqui01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/elqui01.cp.lsst.org_spec.rb
@@ -55,8 +55,8 @@ describe 'elqui01.cp.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.28',
-          version: '1.28.12~rke2r1'
+          release_series: '1.29',
+          version: '1.29.9~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/elqui06.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/elqui06.cp.lsst.org_spec.rb
@@ -54,8 +54,8 @@ describe 'elqui06.cp.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'agent',
-          release_series: '1.28',
-          version: '1.28.12~rke2r1'
+          release_series: '1.29',
+          version: '1.29.9~rke2r1'
         )
       end
 

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -8,25 +8,13 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
   include_examples 'k8snode profile'
   include_examples 'restic common'
 
-  case site
-  when 'dev'
-    it do
-      is_expected.to contain_class('rke2').with(
-        node_type: 'agent',
-        release_series: '1.29',
-        version: '1.29.9~rke2r1',
-        versionlock: true
-      )
-    end
-  else
-    it do
-      is_expected.to contain_class('rke2').with(
-        node_type: 'agent',
-        release_series: '1.28',
-        version: '1.28.12~rke2r1',
-        versionlock: true
-      )
-    end
+  it do
+    is_expected.to contain_class('rke2').with(
+      node_type: 'agent',
+      release_series: '1.29',
+      version: '1.29.9~rke2r1',
+      versionlock: true
+    )
   end
 
   it { expect(catalogue.resource('class', 'rke2')[:config]).to include('server') }

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -8,25 +8,13 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
   include_examples 'k8snode profile'
   include_examples 'restic common'
 
-  case site
-  when 'dev'
-    it do
-      is_expected.to contain_class('rke2').with(
-        node_type: 'server',
-        release_series: '1.29',
-        version: '1.29.9~rke2r1',
-        versionlock: true
-      )
-    end
-  else
-    it do
-      is_expected.to contain_class('rke2').with(
-        node_type: 'server',
-        release_series: '1.28',
-        version: '1.28.12~rke2r1',
-        versionlock: true
-      )
-    end
+  it do
+    is_expected.to contain_class('rke2').with(
+      node_type: 'server',
+      release_series: '1.29',
+      version: '1.29.9~rke2r1',
+      versionlock: true
+    )
   end
 
   it { expect(catalogue.resource('class', 'rke2')[:config]).to include('server') }


### PR DESCRIPTION
During the last summit upgrade i forgot to update `Elqui`, so I'm bumping all sites version to `v1.29.9` (instead of just `DEV`)