### PR TITLE
(cluster/yagan) add CNI static plugin

### DIFF
--- a/hieradata/cluster/kueyen.yaml
+++ b/hieradata/cluster/kueyen.yaml
@@ -4,6 +4,7 @@ clustershell::groupmembers:
 profile::core::ospl::enable_rundir: true
 profile::core::k8snode::enable_dhcp: true
 tuned::active_profile: "latency-performance"
+cni::plugins::enable: ["macvlan", "static"]
 nm::connections:
   em1:  #PXE Boot
     content: |

--- a/hieradata/cluster/yagan.yaml
+++ b/hieradata/cluster/yagan.yaml
@@ -4,3 +4,4 @@ clustershell::groupmembers:
 profile::core::k8snode::enable_dhcp: true
 profile::core::ospl::enable_rundir: true
 tuned::active_profile: "latency-performance"
+cni::plugins::enable: ["macvlan", "static"]

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -104,6 +104,9 @@ lookup_options:
   rke2::config:
     merge:
       strategy: "deep"
+  cni::plugins::enable:
+    merge:
+      strategy: "deep"
 
 timezone::timezone: "UTC"
 chrony::cmdport: 0

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -57,7 +57,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
         is_expected.to contain_class('cni::plugins').with(
           version: '1.2.0',
           checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
-          enable: ['macvlan']
+          enable: %w[macvlan static]
         )
       end
 

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -60,7 +60,7 @@ describe 'yagan01.cp.lsst.org', :sitepp do
         is_expected.to contain_class('cni::plugins').with(
           version: '1.2.0',
           checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
-          enable: ['macvlan']
+          enable: %w[macvlan static]
         )
       end
 

--- a/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan11.cp.lsst.org_spec.rb
@@ -58,7 +58,7 @@ describe 'yagan11.cp.lsst.org', :sitepp do
         is_expected.to contain_class('cni::plugins').with(
           version: '1.2.0',
           checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
-          enable: ['macvlan']
+          enable: %w[macvlan static]
         )
       end
 


### PR DESCRIPTION
in order to put a static IP on the `multus` interface, `static` plugin must be installed on `RKE1` (comes out-of-the-box on RKE2, migration is recommended)