### PR TITLE
(common) bump lsst-dm/s3daemon to sha-57e1aa9

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -572,7 +572,7 @@ restic::bucket: "rubin-bm-backups/%{facts.networking.fqdn}"
 restic::enable_backup: true
 restic::host: "s3.us-east-1.amazonaws.com"
 
-s3daemon_default_image: "ghcr.io/lsst-dm/s3daemon:sha-e117c22"
+s3daemon_default_image: "ghcr.io/lsst-dm/s3daemon:sha-57e1aa9"
 
 pi::config::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete
 pi::cmdline::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete

--- a/spec/hosts/nodes/auxtel-dc01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'auxtel-dc01.cp.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('cp-latiss').with(
           s3_endpoint_url: 'https://s3.cp.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 
@@ -39,7 +39,7 @@ describe 'auxtel-dc01.cp.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss').with(
           s3_endpoint_url: 'https://s3dfrgw.slac.stanford.edu',
           port: 15_580,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/hosts/nodes/auxtel-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.ls.lsst.org_spec.rb
@@ -33,7 +33,7 @@ describe 'auxtel-dc01.ls.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('ls-latiss').with(
           s3_endpoint_url: 'https://s3.ls.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 
@@ -41,7 +41,7 @@ describe 'auxtel-dc01.ls.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss').with(
           s3_endpoint_url: 'https://s3dfrgw.slac.stanford.edu',
           port: 15_580,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/hosts/nodes/auxtel-dc01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'auxtel-dc01.tu.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('tu-latiss').with(
           s3_endpoint_url: 'https://s3.tu.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 
@@ -39,7 +39,7 @@ describe 'auxtel-dc01.tu.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss').with(
           s3_endpoint_url: 'https://s3dfrgw.slac.stanford.edu',
           port: 15_580,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/hosts/nodes/comcam-dc01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-dc01.cp.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'comcam-dc01.cp.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('cp-comcam').with(
           s3_endpoint_url: 'https://s3.cp.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 
@@ -39,7 +39,7 @@ describe 'comcam-dc01.cp.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('sdfembs3-comcam').with(
           s3_endpoint_url: 'https://sdfembs3.sdf.slac.stanford.edu',
           port: 15_580,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'comcam-dc01.tu.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('tu-comcam').with(
           s3_endpoint_url: 'https://s3.tu.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -33,7 +33,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
         is_expected.to contain_s3daemon__instance('ls-lsstcam').with(
           s3_endpoint_url: 'https://s3.ls.lsst.org',
           port: 15_570,
-          image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+          image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
         )
       end
 

--- a/spec/support/spec/lsstcam.rb
+++ b/spec/support/spec/lsstcam.rb
@@ -5,7 +5,7 @@ shared_examples 'lsstcam-dc.cp' do
     is_expected.to contain_s3daemon__instance('cp-lsstcam').with(
       s3_endpoint_url: 'https://s3.cp.lsst.org',
       port: 15_570,
-      image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+      image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
     )
   end
 
@@ -13,7 +13,7 @@ shared_examples 'lsstcam-dc.cp' do
     is_expected.to contain_s3daemon__instance('sdfembs3-lsstcam').with(
       s3_endpoint_url: 'https://sdfembs3.sdf.slac.stanford.edu',
       port: 15_580,
-      image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+      image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
     )
   end
 
@@ -21,7 +21,7 @@ shared_examples 'lsstcam-dc.cp' do
     is_expected.to contain_s3daemon__instance('elqui-lsstcam').with(
       s3_endpoint_url: 'https://s3.elqui.cp.lsst.org',
       port: 15_590,
-      image: 'ghcr.io/lsst-dm/s3daemon:sha-e117c22'
+      image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9'
     )
   end
 end


### PR DESCRIPTION
The new tag includes https://github.com/lsst-dm/s3daemon/pull/15, which will hopefully reduce CPU usage.