### PR TITLE
(node/nfs3.cp.lsst.org) add nodes to  export list

### DIFF
--- a/hieradata/node/nfs3.cp.lsst.org.yaml
+++ b/hieradata/node/nfs3.cp.lsst.org.yaml
@@ -12,6 +12,8 @@ nfs::nfs_exports_global:
       139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       azar03.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)
       comcam-archiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
+      comcam-dc01.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
+      comcam-vs01.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
   /lsstcam:
     clients: >-
       %{facts.networking.ip}/32(ro,nohide,insecure,no_subtree_check,async,root_squash)

--- a/spec/hosts/nodes/nfs3.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/nfs3.cp.lsst.org_spec.rb
@@ -45,7 +45,9 @@ describe 'nfs3.cp.lsst.org', :sitepp do
             '139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
             '139.229.165.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)',
             'azar03.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)',
-            'comcam-archiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)'
+            'comcam-archiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+            'comcam-dc01.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)',
+            'comcam-vs01.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,no_root_squash)'
           )
       end
 


### PR DESCRIPTION
It was requested to mount nfs3.cp.lsst.org on comcam-dc01.cp.lsst.org. This PR adds comcam-dc01 to nfs3 export list. 