### PR TITLE
(role/hexrot) fix nexus packages for hexrot

### DIFF
--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -20,7 +20,6 @@ files:
     subscribe:
       - "Package[runHexEui]"
       - "Package[runRotEui]"
-      - "Package[runM2Cntlr]"
 
 # / on hexrot.cp was formated with xfs fstype=0 (long, long, long ago) and is
 # not compatible with overlayfs[2]

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -72,7 +72,7 @@ profile::ts::nexusctio::repos:
     ensure: "present"
     descr: "CTIO Nexus Repository"
     enabled: false
-    baseurl: "http://cagvm3.ctio.noao.edu/nexus/repository/labview-rpm/rubin/"
+    baseurl: "https://repo-nexus.lsst.org/nexus/repository/ts_yum/releases"
     gpgcheck: false
     target: "/etc/yum.repos.d/nexus-ctio.repo"
   "gpgrubin":

--- a/site/profile/manifests/core/ni_packages.pp
+++ b/site/profile/manifests/core/ni_packages.pp
@@ -5,7 +5,6 @@ class profile::core::ni_packages {
   $hexrot_packages = [
     'runHexEui',
     'runRotEui',
-    'runM2Cntlr',
   ]
   $packages = [
     'git',
@@ -28,7 +27,4 @@ class profile::core::ni_packages {
     install_options => ['--enablerepo','nexus-ctio'];
   }
   ensure_packages($packages)
-  host { 'cagvm3.ctio.noao.edu':
-    ip => '139.229.3.76',
-  }
 }

--- a/spec/support/spec/nexusctio.rb
+++ b/spec/support/spec/nexusctio.rb
@@ -3,7 +3,7 @@
 shared_examples 'nexusctio' do
   it do
     is_expected.to contain_yumrepo('nexus-ctio').with(
-      'baseurl' => 'http://cagvm3.ctio.noao.edu/nexus/repository/labview-rpm/rubin/',
+      'baseurl' => 'https://repo-nexus.lsst.org/nexus/repository/ts_yum/releases',
       'gpgcheck' => false
     )
   end

--- a/spec/support/spec/ni_packages.rb
+++ b/spec/support/spec/ni_packages.rb
@@ -4,7 +4,6 @@ shared_examples 'ni_packages' do
   all_packages = [
     'runHexEui',
     'runRotEui',
-    'runM2Cntlr',
     'git',
     'mlocate',
     'wget',
@@ -24,6 +23,4 @@ shared_examples 'ni_packages' do
   all_packages.each do |pkg|
     it { is_expected.to contain_package(pkg) }
   end
-
-  it { is_expected.to contain_host('cagvm3.ctio.noao.edu').with(ip: '139.229.3.76') }
 end


### PR DESCRIPTION
the `ctio nexus` is no longer available, so Te-Wei moved his `Hexrot` Packages into [repo-nexus.lsst.org](repo-nexus.lsst.org) and removed the used of `runM2Cntlr` as it is now managed by the `ts_m2gui` conda packages now.