### PR TITLE
(role/auxtelmcm) remove tomcat profile

### DIFF
--- a/hieradata/role/auxtelmcm.yaml
+++ b/hieradata/role/auxtelmcm.yaml
@@ -3,7 +3,6 @@ classes:
   - "ccs_sal"
   - "profile::ccs::common"
   - "profile::ccs::graphical"
-  - "profile::ccs::tomcat"
   - "profile::core::auxtelmcm"
   - "profile::core::common"
   - "profile::core::debugutils"
@@ -16,19 +15,6 @@ nginx::ssl_protocols: "TLSv1.2"
 nginx::ssl_ciphers: |
   ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
 nginx::gzip_proxied: "any"
-profile::ccs::tomcat::jars:
-  "mysql-connector-java-5.1.23.jar": "https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.23/mysql-connector-java-5.1.23.jar"
-  "h2-1.4.191.jar": "https://repo1.maven.org/maven2/com/h2database/h2/1.4.191/h2-1.4.191.jar"
-profile::ccs::tomcat::wars:
-  CCSWebTrending.war:
-    war_source: "https://repo-nexus.lsst.org/nexus/repository/ccs-maven2-public/org/lsst/CCSWebTrending/2.3/CCSWebTrending-2.3.war"
-  ImageUtilities.war:
-    war_source: "https://repo-nexus.lsst.org/nexus/repository/ccs-maven2-public/org/lsst/org-lsst-ccs-image-utilities-war/3.1.19/org-lsst-ccs-image-utilities-war-3.1.19.war"
-  FITSInfo.war:
-    war_source: "https://repo-nexus.lsst.org/nexus/repository/ccs-maven2/org/lsst/fits/FITSInfo/1.0.0/FITSInfo-1.0.0.war"
-  rest.war:
-    war_source: "https://repo-nexus.lsst.org/nexus/repository/ccs-maven2-public/org/lsst/org-lsst-ccs-localdb-war/4.1.39/org-lsst-ccs-localdb-war-4.1.39.war"
-
 
 profile::core::systemd::tmpfile:
   docker_tmp.conf:  # XXX short term kludge


### PR DESCRIPTION
This PR removes `profile::ccs::tomcat` from `auxtelmcm` role as its not needed for node auxtel-mcm.cp.lsst.org.