### PR TITLE
(role/auxtel-hcu) add advec kernel module

### DIFF
--- a/hieradata/role/auxtel-hcu.yaml
+++ b/hieradata/role/auxtel-hcu.yaml
@@ -11,6 +11,8 @@ packages:
   - "telnet"
   - "usbutils"
 
+ccs_hcu::advec: true
+
 ccs_hcu::canbus::module: "advSocketCAN"
 ccs_hcu::canbus::version: "1.0.1.0"
 
@@ -19,7 +21,6 @@ ccs_hcu::vldrive::version: "1.5.0"
 
 ccs_hcu::imanager::module: "imanager"
 ccs_hcu::imanager::version: "1.5.1"
-ccs_hcu::imanager: true
 
 nfs::client_enabled: true
 nfs::client_mounts:


### PR DESCRIPTION
This replaces the older imanager kernel module in rhel9.
