### PR TITLE
(pi/pigpio) bump repo from fedora37 to 39

### DIFF
--- a/site/profile/manifests/pi/pigpio.pp
+++ b/site/profile/manifests/pi/pigpio.pp
@@ -4,7 +4,7 @@
 class profile::pi::pigpio {
   yumrepo { 'raspberry-pi':
     descr               => 'Copr repo for raspberry-pi owned by pemensik',
-    baseurl             => 'https://download.copr.fedorainfracloud.org/results/pemensik/raspberry-pi/fedora-37-$basearch/',
+    baseurl             => 'https://download.copr.fedorainfracloud.org/results/pemensik/raspberry-pi/fedora-39-$basearch/',
     skip_if_unavailable => 'true',
     gpgcheck            => '1',
     gpgkey              => 'https://download.copr.fedorainfracloud.org/results/pemensik/raspberry-pi/pubkey.gpg',


### PR DESCRIPTION
package `pigpio` was not been installed because the repo was gone. (note that `fedora39` is also `EOL` since `Nov. 2024`)