### PR TITLE
(node/auxtel-fp01.cp) add lhn interface

### DIFF
--- a/hieradata/node/auxtel-fp01.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-fp01.cp.lsst.org.yaml
@@ -49,13 +49,18 @@ nm::connections:
         id: "eno3"
         uuid: "5dcbb5a8-3425-4dff-a339-7a29e0b3a6c1"
         type: "ethernet"
-        autoconnect: "false"
         interface-name: "eno3"
       ethernet: {}
       ipv4:
-        method: "disabled"
+        address1: "139.229.181.74/29,139.229.181.78"
+        dns: "139.229.160.53;139.229.160.54;139.229.160.55;"
+        dns-search: "cp.lsst.org;"
+        method: "manual"
+        never-default: "true"
+        route1: "172.24.7.0/24,139.229.181.78"
       ipv6:
-        method: "disabled"
+        method: "ignore"
+      proxy: {}
   eno4:
     content:
       connection:

--- a/spec/hosts/nodes/auxtel-fp01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-fp01.cp.lsst.org_spec.rb
@@ -35,7 +35,6 @@ describe 'auxtel-fp01.cp.lsst.org', :sitepp do
 
       %w[
         eno2
-        eno3
       ].each do |i|
         context "with #{i}" do
           let(:interface) { i }
@@ -61,6 +60,18 @@ describe 'auxtel-fp01.cp.lsst.org', :sitepp do
         it_behaves_like 'nm bridge interface'
         it_behaves_like 'nm manual interface'
         it { expect(nm_keyfile['ipv4']['address1']).to eq('192.168.100.251/24') }
+      end
+
+      context 'with eno3' do
+        let(:interface) { 'eno3' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('139.229.181.74/29,139.229.181.78') }
+        it { expect(nm_keyfile['ipv4']['route1']).to eq('172.24.7.0/24,139.229.181.78') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('139.229.160.53;139.229.160.54;139.229.160.55;') }
+        it { expect(nm_keyfile['ipv4']['dns-search']).to eq('cp.lsst.org;') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
       end
 
       context 'with eno4' do


### PR DESCRIPTION
Enables eno3 to serve as lhn interface for auxtel-fp01.cp.lsst.org. @tony-johnson agreed to use the 1G interface as they will only push small size files. 