### PR TITLE
(role/laserrpi) add new udev rule ttyusb

### DIFF
--- a/hieradata/role/laserrpi.yaml
+++ b/hieradata/role/laserrpi.yaml
@@ -4,8 +4,8 @@ classes:
   - "profile::core::docker"
   - "profile::core::gpio"
   - "profile::pi::add_usb"
-  - "profile::pi::ftdi"
   - "profile::pi::pigpio"
+  - "profile::pi::ttyusb"
   - "profile::ts::dco"
 
 files:

--- a/site/profile/manifests/pi/ttyusb.pp
+++ b/site/profile/manifests/pi/ttyusb.pp
@@ -1,0 +1,16 @@
+# @summary
+#   Manages the permissions group for rpi USB devices
+#
+class profile::pi::ttyusb {
+  if defined(Class['profile::core::docker']) {
+    $group = Class['profile::core::docker']['socket_group']
+  } else {
+    $group = '70014'
+  }
+
+  systemd::udev::rule { '90-tty-usb.rules':
+    rules => [
+      "KERNEL==\"ttyUSB[0-9]*\", GROUP=\"${group}\", MODE=\"0660\"",
+    ],
+  }
+}

--- a/spec/classes/pi/ttyusb_spec.rb
+++ b/spec/classes/pi/ttyusb_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::pi::ttyusb' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'ttyusb'
+    end
+  end
+end

--- a/spec/hosts/roles/laserrpi_spec.rb
+++ b/spec/hosts/roles/laserrpi_spec.rb
@@ -33,7 +33,7 @@ describe "#{role} role" do
           include_examples 'docker'
           include_examples('gpio', os_facts:)
           include_examples 'pigpio'
-          include_examples 'ftdi'
+          include_examples 'ttyusb'
           include_examples 'dco'
           include_examples 'add_usb'
 

--- a/spec/support/spec/ttyusb.rb
+++ b/spec/support/spec/ttyusb.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+shared_examples 'ttyusb' do
+  it do
+    is_expected.to contain_systemd__udev__rule('90-tty-usb.rules').with(
+      rules: [
+        'KERNEL=="ttyUSB[0-9]*", GROUP="70014", MODE="0660"',
+      ]
+    )
+  end
+end


### PR DESCRIPTION
this rule replaces the one with the fix vendor ID for a more generic rule that can be more managed.