### PR TITLE
(node/m1m3-vm.cp) add EL9 static network configuration

### DIFF
--- a/hieradata/node/m1m3-vm.cp.lsst.org.yaml
+++ b/hieradata/node/m1m3-vm.cp.lsst.org.yaml
@@ -1,0 +1,18 @@
+---
+nm::connections:
+  ens192:  #fqdn
+    content:
+      connection:
+        id: "ens192"
+        uuid: "d9e9eb1c-a090-4a69-ac08-792c02470e9b"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        address1: "139.229.170.55/24,139.229.170.254"
+        dns: "139.229.160.53;139.229.160.54;139.229.160.55;"
+        dns-search: "cp.lsst.org;"
+        method: "manual"
+      ipv6:
+        method: "disabled"
+      proxy: {}

--- a/spec/hosts/nodes/m1m3-vm.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/m1m3-vm.cp.lsst.org_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'm1m3-vm.cp.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'vmware',
+                            dmi: {
+                              'product' => {
+                                'name' => 'VMware7,1',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'cp',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(2) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('139.229.170.85/24,139.229.170.254') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('139.229.135.53;139.229.135.54;139.229.135.55;') }
+        it { expect(nm_keyfile['ipv4']['dns-search']).to eq('cp.lsst.org;') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
+      end
+    end # on os
+  end # on_supported_os
+end

--- a/spec/hosts/nodes/m1m3-vm.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/m1m3-vm.cp.lsst.org_spec.rb
@@ -27,15 +27,15 @@ describe 'm1m3-vm.cp.lsst.org', :sitepp do
       it { is_expected.to compile.with_all_deps }
 
       include_context 'with nm interface'
-      it { is_expected.to have_nm__connection_resource_count(2) }
+      it { is_expected.to have_nm__connection_resource_count(1) }
 
       context 'with ens192' do
         let(:interface) { 'ens192' }
 
         it_behaves_like 'nm enabled interface'
         it_behaves_like 'nm ethernet interface'
-        it { expect(nm_keyfile['ipv4']['address1']).to eq('139.229.170.85/24,139.229.170.254') }
-        it { expect(nm_keyfile['ipv4']['dns']).to eq('139.229.135.53;139.229.135.54;139.229.135.55;') }
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('139.229.170.55/24,139.229.170.254') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('139.229.160.53;139.229.160.54;139.229.160.55;') }
         it { expect(nm_keyfile['ipv4']['dns-search']).to eq('cp.lsst.org;') }
         it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
       end


### PR DESCRIPTION
Puppet remove the network configuration after a reboot.
This puppet configuration fix the ip address.