### PR TITLE
(rke/rke2) bump DEV rke client v1.6.5 and rke2 k8s v1.30.7

### DIFF
--- a/hieradata/site/dev/role/rke.yaml
+++ b/hieradata/site/dev/role/rke.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::rke::version: "1.6.5"

--- a/hieradata/site/dev/role/rke2agent.yaml
+++ b/hieradata/site/dev/role/rke2agent.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/hieradata/site/dev/role/rke2server.yaml
+++ b/hieradata/site/dev/role/rke2server.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -37,9 +37,9 @@ class profile::core::rke (
   }
 
   $rke_checksum = $version ? {
-    '1.5.10'     => 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e',
     '1.5.12'     => 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
     '1.6.2'      => '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7',
+    '1.6.5'      => '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -68,25 +68,6 @@ describe 'profile::core::rke' do
       end
 
       context 'with version param' do
-        context 'when 1.5.10' do
-          let(:params) do
-            {
-              version: '1.5.10',
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          include_examples 'rke profile'
-
-          it do
-            is_expected.to contain_class('rke').with(
-              version: '1.5.10',
-              checksum: 'cd5d3e8cd77f955015981751c30022cead0bd78f14216fcd1c827c6a7e5cc26e'
-            )
-          end
-        end
-
         context 'when 1.5.12' do
           let(:params) do
             {
@@ -121,6 +102,25 @@ describe 'profile::core::rke' do
             is_expected.to contain_class('rke').with(
               version: '1.6.2',
               checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+            )
+          end
+        end
+
+        context 'when 1.6.5' do
+          let(:params) do
+            {
+              version: '1.6.5',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
+
+          it do
+            is_expected.to contain_class('rke').with(
+              version: '1.6.5',
+              checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
             )
           end
         end

--- a/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ayekan01.ls.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'ayekan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/namkueyen01.dev.lsst.org_spec.rb
@@ -49,7 +49,7 @@ describe 'namkueyen01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.dev.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.dev.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -61,8 +61,8 @@ describe 'ruka01.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.29',
-          version: '1.29.9~rke2r1'
+          release_series: '1.30',
+          version: '1.30.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
@@ -62,8 +62,8 @@ describe 'ruka04.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.29',
-          version: '1.29.9~rke2r1'
+          release_series: '1.30',
+          version: '1.30.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/ruka07.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka07.dev.lsst.org_spec.rb
@@ -62,8 +62,8 @@ describe 'ruka07.dev.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'agent',
-          release_series: '1.29',
-          version: '1.29.9~rke2r1'
+          release_series: '1.30',
+          version: '1.30.7~rke2r1'
         )
       end
 

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -8,13 +8,25 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
   include_examples 'k8snode profile'
   include_examples 'restic common'
 
-  it do
-    is_expected.to contain_class('rke2').with(
-      node_type: 'agent',
-      release_series: '1.29',
-      version: '1.29.9~rke2r1',
-      versionlock: true
-    )
+  case site
+  when 'dev'
+    it do
+      is_expected.to contain_class('rke2').with(
+        node_type: 'agent',
+        release_series: '1.30',
+        version: '1.30.7~rke2r1',
+        versionlock: true
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke2').with(
+        node_type: 'agent',
+        release_series: '1.29',
+        version: '1.29.9~rke2r1',
+        versionlock: true
+      )
+    end
   end
 
   it { expect(catalogue.resource('class', 'rke2')[:config]).to include('server') }

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -8,13 +8,25 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
   include_examples 'k8snode profile'
   include_examples 'restic common'
 
-  it do
-    is_expected.to contain_class('rke2').with(
-      node_type: 'server',
-      release_series: '1.29',
-      version: '1.29.9~rke2r1',
-      versionlock: true
-    )
+  case site
+  when 'dev'
+    it do
+      is_expected.to contain_class('rke2').with(
+        node_type: 'server',
+        release_series: '1.30',
+        version: '1.30.7~rke2r1',
+        versionlock: true
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke2').with(
+        node_type: 'server',
+        release_series: '1.29',
+        version: '1.29.9~rke2r1',
+        versionlock: true
+      )
+    end
   end
 
   it { expect(catalogue.resource('class', 'rke2')[:config]).to include('server') }

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -43,11 +43,21 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  it do
-    is_expected.to contain_class('rke').with(
-      version: '1.6.2',
-      checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
-    )
+  case site
+  when 'dev'
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.6.5',
+        checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.6.2',
+        checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+      )
+    end
   end
 
   it do


### PR DESCRIPTION
this moves `rke client` for rke1 to `1.6.5` to use k8s `v1.30.7` and bumps `RKE2` to k8s `v1.30.7+rke2r1` only for `DEV`