### PR TITLE
(rke/rke2) bump TU rke client v1.6.5 and rke2 k8s v1.30.7

### DIFF
--- a/hieradata/site/tu/role/rke.yaml
+++ b/hieradata/site/tu/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.6.5"

--- a/hieradata/site/tu/role/rke2agent.yaml
+++ b/hieradata/site/tu/role/rke2agent.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/hieradata/site/tu/role/rke2server.yaml
+++ b/hieradata/site/tu/role/rke2server.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -55,8 +55,8 @@ describe 'pillan01.tu.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.29',
-          version: '1.29.9~rke2r1'
+          release_series: '1.30',
+          version: '1.30.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -58,8 +58,8 @@ describe 'pillan08.tu.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'agent',
-          release_series: '1.29',
-          version: '1.29.9~rke2r1'
+          release_series: '1.30',
+          version: '1.30.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.tu.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev'
+  when 'dev', 'tu'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'agent',

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev'
+  when 'dev', 'tu'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'server',

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -44,7 +44,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   end
 
   case site
-  when 'dev'
+  when 'dev', 'tu'
     it do
       is_expected.to contain_class('rke').with(
         version: '1.6.5',


### PR DESCRIPTION
Bump `rke1` client to `1.6.5` to use k8s `v1.30.7` also `rke2` bump on same version.