### PR TITLE
(role/rke) bump LS client to v1.6.5

### DIFF
--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.6.5"

--- a/hieradata/site/ls/role/rke2agent.yaml
+++ b/hieradata/site/ls/role/rke2agent.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/hieradata/site/ls/role/rke2server.yaml
+++ b/hieradata/site/ls/role/rke2server.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.30"
+rke2::version: "1.30.7~rke2r1"

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -50,7 +50,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'chango01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2',
-          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+          version: '1.6.5',
+          checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
         )
       end
 

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'konkong01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2',
-          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+          version: '1.6.5',
+          checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
         )
       end
 

--- a/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'luan01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2',
-          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+          version: '1.6.5',
+          checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
         )
       end
 

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -49,8 +49,8 @@ describe 'manke01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.2',
-          checksum: '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7'
+          version: '1.6.5',
+          checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.6.2'
+          version: '1.6.5'
         )
       end
 

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev', 'tu'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'agent',

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev', 'tu'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'server',

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -44,7 +44,7 @@ shared_examples 'generic rke' do |os_facts:, site:|
   end
 
   case site
-  when 'dev', 'tu'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke').with(
         version: '1.6.5',


### PR DESCRIPTION
January 2025 OS upgrades include the following:

RKE Client is bumped to v.1.6.5 to support K8S version v.1.30.7-rancher-1-1

This version bump will be effective as of Tuesday of next week.

