### PR TITLE
(cluster/gaw) add RKE2 roles to GAW

### DIFF
--- a/hieradata/cluster/gaw/role/rke2agent.yaml
+++ b/hieradata/cluster/gaw/role/rke2agent.yaml
@@ -1,0 +1,7 @@
+---
+classes:
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false
+rke2::config:
+  node-label:
+    - "role=storage-node"

--- a/hieradata/cluster/gaw/role/rke2server.yaml
+++ b/hieradata/cluster/gaw/role/rke2server.yaml
@@ -1,0 +1,7 @@
+---
+classes:
+  - "profile::core::sysctl::rp_filter"
+profile::core::sysctl::rp_filter::enable: false
+rke2::config:
+  node-label:
+    - "role=storage-node"

--- a/spec/hosts/nodes/gaw04.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw04.ls.lsst.org_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'gaw01.ls.lsst.org', :sitepp do
+describe 'gaw04.ls.lsst.org', :sitepp do
   on_supported_os.each do |os, os_facts|
     next unless os =~ %r{almalinux-9-x86_64}
 
@@ -22,7 +22,7 @@ describe 'gaw01.ls.lsst.org', :sitepp do
       end
       let(:node_params) do
         {
-          role: 'rke2server',
+          role: 'rke2agent',
           site: 'ls',
           cluster: 'gaw',
         }
@@ -53,7 +53,7 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke2').with(
-          node_type: 'server',
+          node_type: 'agent',
           release_series: '1.31',
           version: '1.31.8~rke2r1'
         )


### PR DESCRIPTION
This pull request introduces changes to migrate the `gaw` cluster from `rke` to `rke2`, including updates to configuration files and the addition of new test cases. Key updates include enabling `rke2` configuration with node labels, updating the role for nodes, and adding a new spec file for a specific node.

### Migration to `rke2`:

* Updated `hieradata` files (`rke2agent.yaml` and `rke2server.yaml`) to include the `rke2` configuration with a node label for storage nodes and disabled `rp_filter`. (`[hieradata/cluster/gaw/role/rke2agent.yamlR1-R7](diffhunk://#diff-944b7134a8a7f4e760b9cd275c063b308251602a2528f80abe2067b601296180R1-R7)`)
* Changed the role from `rke` to `rke2server` in the `gaw01` node spec file and updated the corresponding `rke` class expectations to `rke2` with new version and release series values. (`[[1]](diffhunk://#diff-1c840baa1e1313ce7634e7873e76d411a5a21c5b4bfb460e2719e4935453738dL25-R25)`, `[[2]](diffhunk://#diff-1c840baa1e1313ce7634e7873e76d411a5a21c5b4bfb460e2719e4935453738dL50-R58)`)

### Test enhancements:

* Added a new spec file for the `gaw04` node to test its configuration as an `rke2agent`, including expectations for node labels, `clustershell` group members, and the `rke2` class configuration. (`[spec/hosts/nodes/gaw04.ls.lsst.org_spec.rbR1-R65](diffhunk://#diff-6c3ac248d916f1cfbfab7930a13adf96797df98bb1215bc91a1858a0c2068754R1-R65)`)
* Updated the `gaw01` node spec file to verify the inclusion of `rke2` configuration with node labels for storage nodes. (`[spec/hosts/nodes/gaw01.ls.lsst.org_spec.rbL36-R41](diffhunk://#diff-1c840baa1e1313ce7634e7873e76d411a5a21c5b4bfb460e2719e4935453738dL36-R41)`)

PR hiera data: https://github.com/lsst-it/lsst-puppet-hiera-private/pull/166
