### PR TITLE
(role/rke2*) disable rke2-snapshot-controller related helm charts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -587,6 +587,9 @@ rke2::config:
     - "%{::cluster}.%{::site}.lsst.org"
   disable:
     - "rke2-ingress-nginx"
+    - "rke2-snapshot-controller"
+    - "rke2-snapshot-controller-crd"
+    - "rke2-snapshot-validation-webhook"
   disable-cloud-controller: true
 
 profile::core::kernel::pquota::ensure: "absent"  # temporary until profile::core::kernel::pquota profile is removed from roles which don't need it

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -23,7 +23,12 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
 
   it do
     expect(catalogue.resource('class', 'rke2')[:config]).to include(
-      'disable' => ['rke2-ingress-nginx']
+      'disable' => %w[
+        rke2-ingress-nginx
+        rke2-snapshot-controller
+        rke2-snapshot-controller-crd
+        rke2-snapshot-validation-webhook
+      ]
     )
   end
 

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -23,7 +23,12 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
 
   it do
     expect(catalogue.resource('class', 'rke2')[:config]).to include(
-      'disable' => ['rke2-ingress-nginx']
+      'disable' => %w[
+        rke2-ingress-nginx
+        rke2-snapshot-controller
+        rke2-snapshot-controller-crd
+        rke2-snapshot-validation-webhook
+      ]
     )
   end
 


### PR DESCRIPTION
As the chart rke2-snapshot-controller-crd contains an out of date crd causing problems with rook and we aren't using this functionality.