### PR TITLE
(cluster/{auxtel,lsstcam}-ccs) add ccs release 39.2.3

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -72,6 +72,9 @@ ccs_software::installations:
   ats-software-39.2.2:
     aliases:
       - "puppet-39.2.2"
+  ats-software-39.2.3:
+    aliases:
+      - "puppet-39.2.3"
 
 ## Used in lookups:
 ccs_site: "summit"

--- a/hieradata/cluster/lsstcam-ccs.yaml
+++ b/hieradata/cluster/lsstcam-ccs.yaml
@@ -119,6 +119,9 @@ ccs_software::installations:
   lsstcam-software-39.2.0:
     aliases:
       - "puppet-39.2.0"
+  lsstcam-software-39.2.3:
+    aliases:
+      - "puppet-39.2.3"
 
 daq::daqsdk::purge: false
 


### PR DESCRIPTION
Notes:

1. Not including comcam
2. lsstcam has skipped 39.2.1 and 39.2.2 (in puppet at least).
