### PR TITLE
(profile::core::rucio) whitespace fix

### DIFF
--- a/site/profile/manifests/core/rucio.pp
+++ b/site/profile/manifests/core/rucio.pp
@@ -58,6 +58,6 @@ class profile::core::rucio () {
 
   #  Install Yum Packages
   package { $yum_packages:
-    ensure   => 'present',
+    ensure => 'present',
   }
 }


### PR DESCRIPTION
For some reason, this started showing as a linting error.
"Unchanged files with check annotations"
"there should be a single space before '=>' on line 61, column 11 (check: space_before_arrow)"
https://github.com/lsst-it/lsst-control/actions/runs/13727542913/job/38397324377