### PR TITLE
(role/hexrot) add/update conda packages

### DIFF
--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -10,6 +10,11 @@ classes:
   - "profile::core::x2go"
   - "profile::ts::hexrot"
   - "profile::ts::nexusctio"
+  - "profile::util::xfce"
+
+packages:
+  - "freeglut-devel"
+
 files:
   /rubin:
     ensure: "directory"
@@ -35,18 +40,39 @@ anaconda::anaconda_version: "Anaconda3-2023.07-2"
 anaconda::python_env_name: "py311"
 anaconda::python_env_version: "3.11"
 anaconda::conda_packages:
+  numpy:
+    channel: "conda-forge"
+    version: "1.26.4"
   pyside6:
     channel: "conda-forge"
-    version: "6.7.0"
+    version: "6.7.2"
   qasync:
     channel: "conda-forge"
-    version: "0.23.0"
+    version: "0.27.1"
   qt6-charts:
     channel: "conda-forge"
-    version: "6.7.0"
+    version: "6.7.2"
+  ts-guitool:
+    channel: "lsstts"
+    version: "0.2.5"
+  ts-hexgui:
+    channel: "lsstts"
+    version: "0.4.1"
+  ts-hexrotcomm:
+    channel: "lsstts"
+    version: "1.3.3"
   ts-m2com:
     channel: "lsstts"
-    version: "1.5.6"
+    version: "1.5.9"
   ts-m2gui:
     channel: "lsstts"
-    version: "1.0.3"
+    version: "1.1.4"
+  ts-mtdomegui:
+    channel: "lsstts"
+    version: "0.4.4"
+  ts-mtdomecom:
+    channel: "lsstts"
+    version: "0.2.4"
+  ts-rotgui:
+    channel: "lsstts"
+    version: "0.4.1"

--- a/site/profile/manifests/core/ni_packages.pp
+++ b/site/profile/manifests/core/ni_packages.pp
@@ -5,6 +5,7 @@ class profile::core::ni_packages {
   $hexrot_packages = [
     'runHexEui',
     'runRotEui',
+    'labview-2023-rte',
   ]
   $packages = [
     'git',

--- a/site/profile/manifests/ts/hexrot.pp
+++ b/site/profile/manifests/ts/hexrot.pp
@@ -6,7 +6,7 @@ class profile::ts::hexrot {
     ensure             => present,
     provider           => git,
     source             => 'https://github.com/lsst-ts/ts_config_mttcs.git',
-    revision           => 'v0.12.8',
+    revision           => 'v0.16.4',
     keep_local_changes => false,
   }
   file { '/etc/profile.d/hexrot_path.sh':
@@ -21,24 +21,35 @@ class profile::ts::hexrot {
     # lint:endignore
     require => Vcsrepo['/opt/ts_config_mttcs'],
   }
-  file { '/rubin/mtm2/python':
+  file { ['/rubin/mtm2/python', '/rubin/rotator/python', '/rubin/hexapod/python', '/rubin/dome/python']:
     ensure => directory,
     owner  => 73006,
     group  => 73006,
   }
-  file { '/rubin/mtm2/python/run_m2gui':
-    ensure => link,
-    owner  => 73006,
-    group  => 73006,
-    target => '/opt/anaconda/envs/py311/bin/run_m2gui',
+
+  $symlinks = {
+    '/rubin/mtm2/python/run_m2gui'     => '/opt/anaconda/envs/py311/bin/run_m2gui',
+    '/rubin/hexapod/python/run_hexgui' => '/opt/anaconda/envs/py311/bin/run_hexgui',
+    '/rubin/dome/python/run_mtdomegui' => '/opt/anaconda/envs/py311/bin/run_mtdomegui',
+    '/rubin/rotator/python/run_rotgui' => '/opt/anaconda/envs/py311/bin/run_rotgui',
   }
-  file { ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2']:
+
+  $symlinks.each |$source, $target| {
+    file { $source:
+      ensure => link,
+      owner  => 73006,
+      group  => 73006,
+      target => $target,
+    }
+  }
+
+  file { ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2', '/rubin/dome']:
     ensure  => directory,
     owner   => 73006,
     group   => 73006,
     recurse => true,
   }
-  file { ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log']:
+  file { ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log', '/rubin/dome/log']:
     ensure => directory,
     owner  => 73006,
     group  => 73006,

--- a/site/profile/manifests/util/xfce.pp
+++ b/site/profile/manifests/util/xfce.pp
@@ -1,0 +1,46 @@
+# @summary
+#   Installs and sets Xfce
+#
+# @param wayland
+#   Use wayland, false by default.
+#
+# @param graphical
+#   sets systemd for graphical or text login.
+#
+class profile::util::xfce (
+  Boolean $wayland = false,
+  Boolean $graphical = true,
+) {
+  include yum
+
+  yum::group { 'Xfce':
+    ensure  => present,
+    timeout => 600,
+  }
+
+  if $wayland == false {
+    file_line { 'disable_wayland':
+      path  => '/etc/gdm/custom.conf',
+      match => '^#?WaylandEnable=',
+      line  => 'WaylandEnable=false',
+    }
+  } else {
+    file_line { 'enable_wayland':
+      path  => '/etc/gdm/custom.conf',
+      match => '^#?WaylandEnable=',
+      line  => 'WaylandEnable=true',
+    }
+  }
+
+  if $graphical {
+    $target = 'graphical.target'
+  } else {
+    $target = 'multi-user.target'
+  }
+
+  exec { "set_systemd_${target}":
+    command => "systemctl set-default ${target}",
+    unless  => "systemctl get-default | grep -q ${target}",
+    path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+  }
+}

--- a/spec/classes/util/xfce_spec.rb
+++ b/spec/classes/util/xfce_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::util::xfce' do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_yum__group('Xfce')
+          .with(
+            ensure: 'present',
+            timeout: 600
+          )
+      }
+
+      context 'when wayland is false' do
+        let(:params) { { wayland: false } }
+
+        it {
+          is_expected.to contain_file_line('disable_wayland')
+            .with(
+              path: '/etc/gdm/custom.conf',
+              match: '^#?WaylandEnable=',
+              line: 'WaylandEnable=false'
+            )
+        }
+      end
+
+      context 'when wayland is true' do
+        let(:params) { { wayland: true } }
+
+        it {
+          is_expected.to contain_file_line('enable_wayland')
+            .with(
+              path: '/etc/gdm/custom.conf',
+              match: '^#?WaylandEnable=',
+              line: 'WaylandEnable=true'
+            )
+        }
+      end
+
+      context 'when graphical is true' do
+        let(:params) { { graphical: true } }
+
+        it {
+          is_expected.to contain_exec('set_systemd_graphical.target')
+            .with(
+              command: 'systemctl set-default graphical.target',
+              unless: 'systemctl get-default | grep -q graphical.target',
+              path: ['/bin', '/usr/bin', '/sbin', '/usr/sbin']
+            )
+        }
+      end
+
+      context 'when graphical is false' do
+        let(:params) { { graphical: false } }
+
+        it {
+          is_expected.to contain_exec('set_systemd_multi-user.target')
+            .with(
+              command: 'systemctl set-default multi-user.target',
+              unless: 'systemctl get-default | grep -q multi-user.target',
+              path: ['/bin', '/usr/bin', '/sbin', '/usr/sbin']
+            )
+        }
+      end
+    end
+  end
+end

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -27,6 +27,8 @@ describe "#{role} role" do
           include_examples 'ni_packages'
           include_examples 'nexusctio'
           it { is_expected.to contain_class('mate') }
+          it { is_expected.to contain_class('profile::util::xfce') }
+          it { is_expected.to contain_package('freeglut-devel') } # missing opengl lib
 
           # XXX hexrot uses devicemapper, so the docker example group isn't included
           it do
@@ -45,31 +47,59 @@ describe "#{role} role" do
               ensure: 'present',
               provider: 'git',
               source: 'https://github.com/lsst-ts/ts_config_mttcs.git',
-              revision: 'v0.12.8',
+              revision: 'v0.16.4',
               keep_local_changes: 'false'
             )
           end
 
           pkgs = {
+            'numpy' => {
+              'channel' => 'conda-forge',
+              'version' => '1.26.4',
+            },
             'pyside6' => {
               'channel' => 'conda-forge',
-              'version' => '6.7.0',
+              'version' => '6.7.2',
             },
             'qasync' => {
               'channel' => 'conda-forge',
-              'version' => '0.23.0',
+              'version' => '0.27.1',
             },
             'qt6-charts' => {
               'channel' => 'conda-forge',
-              'version' => '6.7.0',
+              'version' => '6.7.2',
+            },
+            'ts-guitool' => {
+              'channel' => 'lsstts',
+              'version' => '0.2.5',
+            },
+            'ts-hexgui' => {
+              'channel' => 'lsstts',
+              'version' => '0.4.1',
+            },
+            'ts-hexrotcomm' => {
+              'channel' => 'lsstts',
+              'version' => '1.3.3',
             },
             'ts-m2com' => {
               'channel' => 'lsstts',
-              'version' => '1.5.6',
+              'version' => '1.5.9',
             },
             'ts-m2gui' => {
               'channel' => 'lsstts',
-              'version' => '1.0.3',
+              'version' => '1.1.4',
+            },
+            'ts-mtdomecom' => {
+              'channel' => 'lsstts',
+              'version' => '0.2.4',
+            },
+            'ts-mtdomegui' => {
+              'channel' => 'lsstts',
+              'version' => '0.4.4',
+            },
+            'ts-rotgui' => {
+              'channel' => 'lsstts',
+              'version' => '0.4.1',
             },
           }
 
@@ -96,24 +126,35 @@ describe "#{role} role" do
             )
           end
 
-          it do
-            is_expected.to contain_file('/rubin/mtm2/python').with(
-              ensure: 'directory',
-              owner: '73006',
-              group: '73006'
-            )
+          ['/rubin/mtm2/python', '/rubin/rotator/python', '/rubin/hexapod/python', '/rubin/mtm2/python'].each do |path|
+            it do
+              is_expected.to contain_file(path).with(
+                ensure: 'directory',
+                owner: '73006',
+                group: '73006'
+              )
+            end
           end
 
-          it do
-            is_expected.to contain_file('/rubin/mtm2/python/run_m2gui').with(
-              ensure: 'link',
-              owner: '73006',
-              group: '73006',
-              target: '/opt/anaconda/envs/py311/bin/run_m2gui'
-            )
+          symlinks = {
+            '/rubin/mtm2/python/run_m2gui' => '/opt/anaconda/envs/py311/bin/run_m2gui',
+            '/rubin/hexapod/python/run_hexgui' => '/opt/anaconda/envs/py311/bin/run_hexgui',
+            '/rubin/dome/python/run_mtdomegui' => '/opt/anaconda/envs/py311/bin/run_mtdomegui',
+            '/rubin/rotator/python/run_rotgui' => '/opt/anaconda/envs/py311/bin/run_rotgui'
+          }
+
+          symlinks.each do |source, dst|
+            it do
+              is_expected.to contain_file(source).with(
+                ensure: 'link',
+                owner: '73006',
+                group: '73006',
+                target: dst
+              )
+            end
           end
 
-          ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2'].each do |path|
+          ['/rubin/rotator', '/rubin/hexapod', '/rubin/mtm2', '/rubin/dome'].each do |path|
             it do
               is_expected.to contain_file(path).with(
                 ensure: 'directory',
@@ -124,7 +165,7 @@ describe "#{role} role" do
             end
           end
 
-          ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log'].each do |path|
+          ['/rubin/rotator/log', '/rubin/hexapod/log', '/rubin/mtm2/log', '/rubin/dome/log'].each do |path|
             it do
               is_expected.to contain_file(path).with(
                 ensure: 'directory',

--- a/spec/support/spec/ni_packages.rb
+++ b/spec/support/spec/ni_packages.rb
@@ -4,6 +4,7 @@ shared_examples 'ni_packages' do
   all_packages = [
     'runHexEui',
     'runRotEui',
+    'labview-2023-rte',
     'git',
     'mlocate',
     'wget',


### PR DESCRIPTION
- added `conda` packages: `ts-rotgui`, `ts-hexgui`, `ts-mtdomegui`, `ts-guitools`
- set permissions for their logs and python folder
- creates the symblinks for the binaries
- updates versions for ts-mt2gui (conda) and ts_config_mttcs (repo)
- added quick profile to enable xfce and set GUI by default
- got NI Lab View runtime into the local Nexus, pulling from there. (ni_packages)
