### PR TITLE
(role/daq-mgt) Update DAQ to R5-V13.3

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V13.2"
+daq::daqsdk::version: "R5-V13.3"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -181,6 +181,9 @@ profile::daq::sysctl::sysctls:
   net.core.wmem_max:
     value: 18874368
     target: *daqccs
+  kernel.sched_rt_runtime_us:
+    value: -1
+    target: *daqccs
 
 profile::archive::data::files:
   /data: &rootdir

--- a/spec/classes/daq/sysctl_spec.rb
+++ b/spec/classes/daq/sysctl_spec.rb
@@ -8,7 +8,7 @@ describe 'profile::daq::sysctl' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to have_sysctl__value_resource_count(2) }
+      it { is_expected.to have_sysctl__value_resource_count(3) }
 
       include_examples 'lsst-daq sysctls'
 


### PR DESCRIPTION
Update Camera to DAQ R5-13.3. Note that this also requires the setting of the sysctl parameter kernel.sched_rt_runtime_us=-1 to allow the gds_relay to change CPUSchedulingPolicy and CPUSchedulingPriority.