### PR TITLE
(common/firewall) add antu and set port for node_exporter

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -373,11 +373,11 @@ ipset::sets:
       - "140.252.146.0/23"
       - "198.19.0.0/16"
       - "10.0.0.0/8"
-  ayekan:  # ayekan cluster
+  antu:  # antu monitoring cluster ls
     ensure: "present"
     type: "hash:net"
     set:
-      - "139.229.144.0/26"
+      - "139.229.154.64/26"
   dev:  # dev site hosts
     ensure: "present"
     type: "hash:net"

--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -50,6 +50,21 @@ accounts::user_list:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN16b56V3j7wot509IlRvOFXaLxI9AH9/eOr1WuLEdpGoQ3lDuz26P6zFLbopjgsZxdzxE492QAmGpdUkn+Ducny1JK83L0N/d6INrM48fQeiUiSsN/YKua9qO8QQbvTsiiKanj38u9x1vOfqKn2/kK7BKAZblr+qT7U6nofMFlG3zJpNOCAIHyd4DJRrWB+xPR1YRwljV6BOtpI5+/FwdoX+/61cdsP0895iejDlnYRNFBYWRdGHDdDN6yfSNy00D/ADwaZP9sO+gyvHPqz/saPFYx8Petbhl/PlUjqWx7sktQxPgpMPBU/KQU5SEd5RkcT+CVjLHuHfOa3jXEdVx foreman-proxy@foreman.cp.lsst.org"
 
 profile::core::common::disable_ipv6: true
+
+profile::core::firewall::firewall:
+  "100 accept node_exporter":
+    proto: "tcp"
+    state: "NEW"
+    ipset: "antu src"
+    dport: "9100"
+    jump: "accept"
+  "101 accept node_exporter":
+    proto: "tcp"
+    state: "NEW"
+    ipset: "dev src"  # allow ruka to access node_exporter
+    dport: "9100"
+    jump: "accept"
+
 profile::core::docker::version: "24.0.9"
 
 ccs_sal::dds: false

--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -68,7 +68,7 @@ profile::core::firewall::firewall:
   "100 accept node_exporter":
     proto: "tcp"
     state: "NEW"
-    ipset: "ayekan src"
+    ipset: "antu src"
     dport: "9100"
     jump: "accept"
   "101 accept node_exporter":

--- a/hieradata/site/ls.yaml
+++ b/hieradata/site/ls.yaml
@@ -52,7 +52,13 @@ profile::core::firewall::firewall:
   "100 accept node_exporter":
     proto: "tcp"
     state: "NEW"
-    ipset: "ayekan src"
+    ipset: "antu src"
+    dport: "9100"
+    jump: "accept"
+  "101 accept node_exporter":
+    proto: "tcp"
+    state: "NEW"
+    ipset: "dev src"  # allow ruka to access node_exporter
     dport: "9100"
     jump: "accept"
 

--- a/spec/support/spec/firewall.rb
+++ b/spec/support/spec/firewall.rb
@@ -56,12 +56,12 @@ end
 
 shared_examples 'firewall node_exporter scraping' do |site:|
   case site
-  when 'dev'
+  when 'dev', 'ls', 'cp'  # just not TU
     it do
       is_expected.to contain_firewall('100 accept node_exporter').with(
         proto: 'tcp',
         state: 'NEW',
-        ipset: 'ayekan src',
+        ipset: 'antu src',
         dport: '9100',
         jump: 'accept'
       )
@@ -72,16 +72,6 @@ shared_examples 'firewall node_exporter scraping' do |site:|
         proto: 'tcp',
         state: 'NEW',
         ipset: 'dev src',
-        dport: '9100',
-        jump: 'accept'
-      )
-    end
-  when 'ls'
-    it do
-      is_expected.to contain_firewall('100 accept node_exporter').with(
-        proto: 'tcp',
-        state: 'NEW',
-        ipset: 'ayekan src',
         dport: '9100',
         jump: 'accept'
       )

--- a/spec/support/spec/ipset.rb
+++ b/spec/support/spec/ipset.rb
@@ -30,9 +30,9 @@ shared_examples 'ipset' do
   end
 
   it do
-    is_expected.to contain_ipset__set('ayekan').with_set(
+    is_expected.to contain_ipset__set('antu').with_set(
       %w[
-        139.229.144.0/26
+        139.229.154.64/26
       ]
     ).that_comes_before('Class[firewall]')
   end


### PR DESCRIPTION
- adds the `ipset` entry for `antu`.
- replaces `ayekan` with `antu` on the `firewall rule`.
- sets firewall rule for dev on port `9100`