### PR TITLE
(role/rke2) set dhcp to service_only on multus clusters

### DIFF
--- a/hieradata/cluster/konkong/role/rke2agent.yaml
+++ b/hieradata/cluster/konkong/role/rke2agent.yaml
@@ -3,6 +3,7 @@ classes:
   - "profile::core::sysctl::lhn"
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/konkong/role/rke2server.yaml
+++ b/hieradata/cluster/konkong/role/rke2server.yaml
@@ -3,6 +3,7 @@ classes:
   - "profile::core::sysctl::lhn"
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/manke/role/rke2agent.yaml
+++ b/hieradata/cluster/manke/role/rke2agent.yaml
@@ -3,6 +3,7 @@ classes:
   - "profile::core::sysctl::lhn"
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/manke/role/rke2server.yaml
+++ b/hieradata/cluster/manke/role/rke2server.yaml
@@ -3,6 +3,7 @@ classes:
   - "profile::core::sysctl::lhn"
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/pillan/role/rke2agent.yaml
+++ b/hieradata/cluster/pillan/role/rke2agent.yaml
@@ -2,6 +2,7 @@
 classes:
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/pillan/role/rke2server.yaml
+++ b/hieradata/cluster/pillan/role/rke2server.yaml
@@ -2,6 +2,7 @@
 classes:
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/yagan/role/rke2agent.yaml
+++ b/hieradata/cluster/yagan/role/rke2agent.yaml
@@ -2,6 +2,7 @@
 classes:
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/hieradata/cluster/yagan/role/rke2server.yaml
+++ b/hieradata/cluster/yagan/role/rke2server.yaml
@@ -2,6 +2,7 @@
 classes:
   - "profile::core::sysctl::rp_filter"
 profile::core::sysctl::rp_filter::enable: false
+profile::core::k8snode::enable_dhcp: 'service_only'
 rke2::config:
   node-label:
     - "role=storage-node"

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -69,7 +69,7 @@ describe 'konkong01.ls.lsst.org', :sitepp do
         )
       end
 
-      it { is_expected.to contain_class('cni::plugins::dhcp') }
+      it { is_expected.to contain_class('cni::plugins::dhcp::service') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(10) }

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -61,7 +61,7 @@ describe 'manke01.ls.lsst.org', :sitepp do
         )
       end
 
-      it { is_expected.to contain_class('cni::plugins::dhcp') }
+      it { is_expected.to contain_class('cni::plugins::dhcp::service') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(14) }

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -69,7 +69,7 @@ describe 'pillan01.tu.lsst.org', :sitepp do
         )
       end
 
-      it { is_expected.to contain_class('cni::plugins::dhcp') }
+      it { is_expected.to contain_class('cni::plugins::dhcp::service') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(14) }

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -72,7 +72,7 @@ describe 'pillan08.tu.lsst.org', :sitepp do
         )
       end
 
-      it { is_expected.to contain_class('cni::plugins::dhcp') }
+      it { is_expected.to contain_class('cni::plugins::dhcp::service') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       # 2 extra instances in the catalog for the rename interfaces

--- a/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yagan01.cp.lsst.org_spec.rb
@@ -71,7 +71,7 @@ describe 'yagan01.cp.lsst.org', :sitepp do
         )
       end
 
-      it { is_expected.to contain_class('cni::plugins::dhcp') }
+      it { is_expected.to contain_class('cni::plugins::dhcp::service') }
       it { is_expected.to contain_class('profile::core::ospl').with_enable_rundir(true) }
 
       it { is_expected.to have_nm__connection_resource_count(12) }


### PR DESCRIPTION
this should solve the version problem between the dhcp and macvlan (using the defaults in rke2)