### PR TITLE
(role/hexrot) bump mtdomegui and mtdomecom versions

### DIFF
--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -69,10 +69,10 @@ anaconda::conda_packages:
     version: "1.1.4"
   ts-mtdomegui:
     channel: "lsstts"
-    version: "0.4.4"
+    version: "0.4.6"
   ts-mtdomecom:
     channel: "lsstts"
-    version: "0.2.4"
+    version: "0.2.5"
   ts-rotgui:
     channel: "lsstts"
     version: "0.4.1"

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -91,11 +91,11 @@ describe "#{role} role" do
             },
             'ts-mtdomecom' => {
               'channel' => 'lsstts',
-              'version' => '0.2.4',
+              'version' => '0.2.5',
             },
             'ts-mtdomegui' => {
               'channel' => 'lsstts',
-              'version' => '0.4.4',
+              'version' => '0.4.6',
             },
             'ts-rotgui' => {
               'channel' => 'lsstts',


### PR DESCRIPTION
bump in versions:
-     ts-mtdomegui: v0.4.6
-     ts-mtdomecom: v0.2.5