### PR TITLE
(role/hexrot) mayor bump python 3.12 and conda packages

### DIFF
--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -36,43 +36,54 @@ accounts::group_list:
     gid: 70014
     forcelocal: true
 
+profile::ts::hexrot::ts_config_mttcs_version: "v0.17.1"
+
 anaconda::anaconda_version: "Anaconda3-2023.07-2"
-anaconda::python_env_name: "py311"
-anaconda::python_env_version: "3.11"
+anaconda::python_env_name: "py312"
+anaconda::python_env_version: "3.12"
 anaconda::conda_packages:
   numpy:
     channel: "conda-forge"
-    version: "1.26.4"
+    version: "2.0.2"
   pyside6:
     channel: "conda-forge"
-    version: "6.7.2"
+    version: "6.8.3"
   qasync:
     channel: "conda-forge"
     version: "0.27.1"
   qt6-charts:
     channel: "conda-forge"
-    version: "6.7.2"
+    version: "6.8.3"
   ts-guitool:
     channel: "lsstts"
-    version: "0.2.5"
+    version: "0.2.6"
   ts-hexgui:
     channel: "lsstts"
-    version: "0.4.1"
+    version: "0.4.2"
   ts-hexrotcomm:
     channel: "lsstts"
-    version: "1.3.3"
+    version: "1.3.5"
   ts-m2com:
     channel: "lsstts"
-    version: "1.5.9"
+    version: "1.5.11"
   ts-m2gui:
     channel: "lsstts"
-    version: "1.1.4"
-  ts-mtdomegui:
-    channel: "lsstts"
-    version: "0.4.9"
+    version: "1.1.5"
   ts-mtdomecom:
     channel: "lsstts"
     version: "0.2.8"
+  ts-mtdomegui:
+    channel: "lsstts"
+    version: "0.4.9"
   ts-rotgui:
     channel: "lsstts"
-    version: "0.4.1"
+    version: "0.4.2"
+  ts-salobj:
+    channel: "lsstts"
+    version: "8.2.1"
+  ts-tcpip:
+    channel: "lsstts"
+    version: "2.1.0"
+  ts-xml:
+    channel: "lsstts"
+    version: "23.1.0"

--- a/site/profile/manifests/ts/hexrot.pp
+++ b/site/profile/manifests/ts/hexrot.pp
@@ -1,12 +1,15 @@
 # @summary
 # Sets up repos and symlinks for hexrot
-
-class profile::ts::hexrot {
+# @param ts_config_mttcs_version
+#   sets the repo version of the config
+class profile::ts::hexrot (
+  String $ts_config_mttcs_version,
+) {
   vcsrepo { '/opt/ts_config_mttcs':
     ensure             => present,
     provider           => git,
     source             => 'https://github.com/lsst-ts/ts_config_mttcs.git',
-    revision           => 'v0.16.4',
+    revision           => $ts_config_mttcs_version,
     keep_local_changes => false,
   }
   file { '/etc/profile.d/hexrot_path.sh':

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -47,7 +47,7 @@ describe "#{role} role" do
               ensure: 'present',
               provider: 'git',
               source: 'https://github.com/lsst-ts/ts_config_mttcs.git',
-              revision: 'v0.16.4',
+              revision: 'v0.17.1',
               keep_local_changes: 'false'
             )
           end
@@ -55,11 +55,11 @@ describe "#{role} role" do
           pkgs = {
             'numpy' => {
               'channel' => 'conda-forge',
-              'version' => '1.26.4',
+              'version' => '2.0.2',
             },
             'pyside6' => {
               'channel' => 'conda-forge',
-              'version' => '6.7.2',
+              'version' => '6.8.3',
             },
             'qasync' => {
               'channel' => 'conda-forge',
@@ -67,27 +67,27 @@ describe "#{role} role" do
             },
             'qt6-charts' => {
               'channel' => 'conda-forge',
-              'version' => '6.7.2',
+              'version' => '6.8.3',
             },
             'ts-guitool' => {
               'channel' => 'lsstts',
-              'version' => '0.2.5',
+              'version' => '0.2.6',
             },
             'ts-hexgui' => {
               'channel' => 'lsstts',
-              'version' => '0.4.1',
+              'version' => '0.4.2',
             },
             'ts-hexrotcomm' => {
               'channel' => 'lsstts',
-              'version' => '1.3.3',
+              'version' => '1.3.5',
             },
             'ts-m2com' => {
               'channel' => 'lsstts',
-              'version' => '1.5.9',
+              'version' => '1.5.11',
             },
             'ts-m2gui' => {
               'channel' => 'lsstts',
-              'version' => '1.1.4',
+              'version' => '1.1.5',
             },
             'ts-mtdomecom' => {
               'channel' => 'lsstts',
@@ -99,15 +99,27 @@ describe "#{role} role" do
             },
             'ts-rotgui' => {
               'channel' => 'lsstts',
-              'version' => '0.4.1',
+              'version' => '0.4.2',
+            },
+            'ts-salobj' => {
+              'channel' => 'lsstts',
+              'version' => '8.2.1',
+            },
+            'ts-tcpip' => {
+              'channel' => 'lsstts',
+              'version' => '2.1.0',
+            },
+            'ts-xml' => {
+              'channel' => 'lsstts',
+              'version' => '23.1.0',
             },
           }
 
           it do
             is_expected.to contain_class('anaconda').with(
               anaconda_version: 'Anaconda3-2023.07-2',
-              python_env_name: 'py311',
-              python_env_version: '3.11',
+              python_env_name: 'py312',
+              python_env_version: '3.12',
               conda_packages: pkgs
             )
           end


### PR DESCRIPTION
- DM went to python 3.12.
- bump most packages version.
- added few more packages (re order everything in alphabetical order, including tests, because it was making mad.)
- changed behavior with repo version, now is set on yaml manifest and pass to the class.