### PR TITLE
(role/rke/rke2) bump LS client to v1.7.6 / rke2 k8s 1.31.7~rke2r1

### DIFF
--- a/hieradata/site/ls/role/rke.yaml
+++ b/hieradata/site/ls/role/rke.yaml
@@ -1,2 +1,3 @@
 ---
 profile::core::docker::version: "24.0.9"
+profile::core::rke::version: "1.7.6"

--- a/hieradata/site/ls/role/rke2agent.yaml
+++ b/hieradata/site/ls/role/rke2agent.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.31"
+rke2::version: "1.31.7~rke2r1"

--- a/hieradata/site/ls/role/rke2server.yaml
+++ b/hieradata/site/ls/role/rke2server.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.31"
+rke2::version: "1.31.7~rke2r1"

--- a/hieradata/site/tu/role/rke2agent.yaml
+++ b/hieradata/site/tu/role/rke2agent.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.31"
+rke2::version: "1.31.7~rke2r1"

--- a/hieradata/site/tu/role/rke2server.yaml
+++ b/hieradata/site/tu/role/rke2server.yaml
@@ -1,0 +1,3 @@
+---
+rke2::release_series: "1.31"
+rke2::version: "1.31.7~rke2r1"

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -40,6 +40,7 @@ class profile::core::rke (
     '1.5.12'     => 'f0d1f6981edbb4c93f525ee51bc2a8ad729ba33c04f21a95f5fc86af4a7af586',
     '1.6.2'      => '68608a97432b4472d3e8f850a7bde0119582ea80fbb9ead923cd831ca97db1d7',
     '1.6.5'      => '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7',
+    '1.7.6'      => 'a6ef89ac3042e066b0596cb38d5bff0192b84a7d4b6ed5b14cddc4bcfd5c9cd9',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -50,7 +50,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.5'
+          version: '1.7.6'
         )
       end
 

--- a/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/chango01.ls.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'chango01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.6.5'
+          version: '1.7.6'
         )
       end
 

--- a/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/gaw01.ls.lsst.org_spec.rb
@@ -48,8 +48,8 @@ describe 'gaw01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('rke').with(
-          version: '1.6.5',
-          checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
+          version: '1.7.6',
+          checksum: 'a6ef89ac3042e066b0596cb38d5bff0192b84a7d4b6ed5b14cddc4bcfd5c9cd9'
         )
       end
 

--- a/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/konkong01.ls.lsst.org_spec.rb
@@ -55,8 +55,8 @@ describe 'konkong01.ls.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.30',
-          version: '1.30.7~rke2r1'
+          release_series: '1.31',
+          version: '1.31.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/luan01.ls.lsst.org_spec.rb
@@ -58,8 +58,8 @@ describe 'luan01.ls.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.30',
-          version: '1.30.7~rke2r1'
+          release_series: '1.31',
+          version: '1.31.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -56,8 +56,8 @@ describe 'manke01.ls.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.30',
-          version: '1.30.7~rke2r1'
+          release_series: '1.31',
+          version: '1.31.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -55,8 +55,8 @@ describe 'pillan01.tu.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'server',
-          release_series: '1.30',
-          version: '1.30.7~rke2r1'
+          release_series: '1.31',
+          version: '1.31.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan08.tu.lsst.org_spec.rb
@@ -58,8 +58,8 @@ describe 'pillan08.tu.lsst.org', :sitepp do
       it do
         is_expected.to contain_class('rke2').with(
           node_type: 'agent',
-          release_series: '1.30',
-          version: '1.30.7~rke2r1'
+          release_series: '1.31',
+          version: '1.31.7~rke2r1'
         )
       end
 

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_class('profile::core::rke').with(
-          version: '1.6.5'
+          version: '1.7.6'
         )
       end
 

--- a/spec/hosts/roles/rke2agent_spec.rb
+++ b/spec/hosts/roles/rke2agent_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2agent' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'agent',

--- a/spec/hosts/roles/rke2server_spec.rb
+++ b/spec/hosts/roles/rke2server_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'generic rke2server' do |os_facts:, site:|
   include_examples 'restic common'
 
   case site
-  when 'dev'
+  when 'dev', 'tu', 'ls'
     it do
       is_expected.to contain_class('rke2').with(
         node_type: 'server',

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -43,11 +43,21 @@ shared_examples 'generic rke' do |os_facts:, site:|
     )
   end
 
-  it do
-    is_expected.to contain_class('rke').with(
-      version: '1.6.5',
-      checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
-    )
+  case site
+  when 'ls'
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.7.6',
+        checksum: 'a6ef89ac3042e066b0596cb38d5bff0192b84a7d4b6ed5b14cddc4bcfd5c9cd9'
+      )
+    end
+  else
+    it do
+      is_expected.to contain_class('rke').with(
+        version: '1.6.5',
+        checksum: '80694373496abd5033cb97c2512f2c36c933d301179881e1d28bf7b78efab3e7'
+      )
+    end
   end
 
   it do


### PR DESCRIPTION
April 2025 OS upgrades include the following:

RKE Client is bumped to v1.7.6 to support K8S version v1.31.7-rancher-1-1

RKE2 was bumped to 1.31.7~rke2r1 along with Pillan, who is all alone in the north.

This version bump will be effective tomorrow. 