### PR TITLE
(role/daq-mgt) Update DAQ to R5-V13.8

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -24,7 +24,7 @@ chrony::queryhosts:
   - "192.168/16"
 chrony::clientlog: true
 
-daq::daqsdk::version: "R5-V13.7"
+daq::daqsdk::version: "R5-V13.8"
 daq::rptsdk::version: "V3.5.3"
 
 # dhcp for DAQ + clients


### PR DESCRIPTION
I know what you’re thinking, wasn’t  there just a v13.7? Yes, but we’ll want both available when we try v13.8. It swaps the GREB sensors in Guider mode, and we may want to back it out in a hurry. Thus, two new releases in the same day.