### PR TITLE
(role/hexrot) bump ts-m2gui to v1.1.6

### DIFF
--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -68,7 +68,7 @@ anaconda::conda_packages:
     version: "1.5.11"
   ts-m2gui:
     channel: "lsstts"
-    version: "1.1.5"
+    version: "1.1.6"
   ts-mtdomecom:
     channel: "lsstts"
     version: "0.2.8"

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -87,7 +87,7 @@ describe "#{role} role" do
             },
             'ts-m2gui' => {
               'channel' => 'lsstts',
-              'version' => '1.1.5',
+              'version' => '1.1.6',
             },
             'ts-mtdomecom' => {
               'channel' => 'lsstts',


### PR DESCRIPTION
- bump conda package `ts-m2gui` to version `1.1.6`