### PR TITLE
(common) bump docker version to 25.0.3

### DIFF
--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -128,7 +128,7 @@ profile::core::yum::lsst_ts_private::repos:
     gpgcheck: false
     target: "/etc/yum.repos.d/lsst-ts-private.repo"
 
-profile::core::docker::version: "24.0.9"
+profile::core::docker::version: "25.0.3"
 
 profile::core::sysctl::lhn::sysctls:
   # lhn tuning

--- a/site/profile/data/osfamily/RedHat/major/8.yaml
+++ b/site/profile/data/osfamily/RedHat/major/8.yaml
@@ -6,7 +6,7 @@ profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-    version: "1.6.21"
+    version: "1.7.22"
     release: "3.1.el8"
   docker-ce:
     ensure: "present"
@@ -31,5 +31,5 @@ profile::core::docker::versionlock:
     release: *docker_release
   docker-compose-plugin:
     ensure: "present"
-    version: "2.17.3"
+    version: "2.24.6"
     release: *docker_release

--- a/site/profile/data/osfamily/RedHat/major/9.yaml
+++ b/site/profile/data/osfamily/RedHat/major/9.yaml
@@ -12,7 +12,7 @@ profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-    version: "1.6.21"
+    version: "1.7.22"
     release: "3.1.el9"
   docker-ce:
     ensure: "present"
@@ -37,7 +37,7 @@ profile::core::docker::versionlock:
     release: *docker_release
   docker-compose-plugin:
     ensure: "present"
-    version: "2.17.3"
+    version: "2.24.6"
     release: *docker_release
 
 profile::core::gpio::packages:

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -9,7 +9,7 @@ describe 'profile::core::docker' do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'docker', docker_version: '24.0.9'
+      include_examples 'docker', docker_version: '25.0.3'
 
       it do
         is_expected.to contain_systemd__dropin_file('wait-for-docker-group.conf').with(

--- a/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/antu01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'antu01.ls.lsst.org', :sitepp do
       include_examples 'baremetal'
       include_context 'with nm interface'
       include_examples 'ceph cluster'
-      include_examples 'docker', docker_version: '24.0.9'
+      include_examples 'docker', docker_version: '25.0.3'
 
       it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)

--- a/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/kueyen01.dev.lsst.org_spec.rb
@@ -27,7 +27,7 @@ describe 'kueyen01.dev.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'docker', docker_version: '24.0.9'
+      include_examples 'docker', docker_version: '25.0.3'
       include_examples 'baremetal'
       include_examples 'ceph cluster'
       include_context 'with nm interface'

--- a/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lukay01.cp.lsst.org_spec.rb
@@ -30,7 +30,7 @@ describe 'lukay01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'docker', docker_version: '24.0.9'
+      include_examples 'docker', docker_version: '25.0.3'
       include_examples 'baremetal'
       include_examples 'ceph cluster'
       include_context 'with nm interface'

--- a/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/yepun01.cp.lsst.org_spec.rb
@@ -30,7 +30,7 @@ describe 'yepun01.cp.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'docker', docker_version: '24.0.9'
+      include_examples 'docker', docker_version: '25.0.3'
       include_examples 'baremetal'
       include_context 'with nm interface'
       include_examples 'ceph cluster'

--- a/spec/support/spec/docker.rb
+++ b/spec/support/spec/docker.rb
@@ -35,7 +35,7 @@ shared_examples 'docker' do |docker_version: nil|
 
   it do
     is_expected.to contain_yum__versionlock('containerd.io').with(
-      version: '1.6.21'
+      version: '1.7.22'
     )
   end
 
@@ -47,7 +47,7 @@ shared_examples 'docker' do |docker_version: nil|
 
   it do
     is_expected.to contain_yum__versionlock('docker-compose-plugin').with(
-      version: '2.17.3'
+      version: '2.24.6'
     )
   end
 


### PR DESCRIPTION
Bump docker version along with related packages. 

Im testing this on test01.ls.lsst.org with ess role applied. 