### PR TITLE
(theforeman/puppetserver_foreman) bump version 4.2.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -118,7 +118,7 @@ mod 'theforeman/dns', '11.1.0'
 mod 'theforeman/foreman', git: 'https://github.com/lsst-it/puppet-foreman', ref: '23f86f4'  # 20.2.0 + dep updates
 mod 'theforeman/foreman_proxy', git: 'https://github.com/lsst-it/puppet-foreman_proxy', ref: '90af64a'  # https://github.com/theforeman/puppet-foreman_proxy/pull/772 https://github.com/theforeman/puppet-foreman_proxy/pull/816
 mod 'theforeman/puppet', '21.0.0'
-mod 'theforeman/puppetserver_foreman', '4.2.0'
+mod 'theforeman/puppetserver_foreman', '4.2.1'
 mod 'theforeman/tftp', '9.1.0'
 mod 'treydock/clustershell', '4.0.0'
 mod 'treydock/perfsonar', git: 'https://github.com/lsst-it/puppet-module-perfsonar', ref: '6e9449e'  # 4.1.0 + https://github.com/treydock/puppet-module-perfsonar/pull/26


### PR DESCRIPTION
- they removed support for `ruby 2.6` in `4.2.0` and that caused issues with the reports on `foreman`, well, they put it back again in `4.2.1`.