### PR TITLE
(site/dev) add Kueyen Fluent Bit forward target in Puppet config

### DIFF
--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -23,6 +23,16 @@ rsyslog::config::actions:
       StreamDriver: "ossl"
       StreamDriverMode: "1"
       StreamDriverAuthMode: "anon"
+  fluentbit_kueyen:
+    type: "omfwd"
+    facility: "*.*"
+    config:
+      target: "rsyslog.fluent.kueyen.dev.lsst.org"
+      port: 5140
+      protocol: "tcp"
+      StreamDriver: "ossl"
+      StreamDriverMode: "1"
+      StreamDriverAuthMode: "anon"
 # The following keys are shared between the `dhcp` and `resolv_conf` classes:
 # - dhcp::dnsdomain
 # - dhcp::nameservers


### PR DESCRIPTION
- Added new  omfwd action to rsyslog::config::actions

- Target: rsyslog.fluent.kueyen.dev.lsst.org:5140 over TCP with ossl

- Matches existing configuration style for ayekan and ruka targets

- Ensures logs are forwarded to Fluent Bit in the Kueyen environment