### PR TITLE
(site/cp/cluster/lsstcam-ccs) add s3daemon|s3nd sdfembs3-lsstcam-test*

### DIFF
--- a/hieradata/site/cp/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/cp/cluster/lsstcam-ccs.yaml
@@ -32,13 +32,13 @@ s3daemon::instances:
       S3ND_UPLOAD_TRIES: "5"
   sdfembs3-lsstcam:
     image: "%{alias('s3daemon_default_image')}"
-    env:
+    env: &sdfembs3
       S3_ENDPOINT_URL: "https://sdfembs3.sdf.slac.stanford.edu"
       S3DAEMON_PORT: 15580
       S3DAEMON_HOST: "0.0.0.0"  # allow connections from other nodes for testing
   sdfembs3-lsstcam-s3nd:
     image: "%{alias('s3nd_default_image')}"
-    env:
+    env: &sdfembss3nd
       S3ND_ENDPOINT_URL: "https://sdfembs3.sdf.slac.stanford.edu"
       S3ND_PORT: 15581
       S3ND_HOST: ""  # allow connections from other nodes for testing
@@ -48,3 +48,13 @@ s3daemon::instances:
       S3ND_UPLOAD_TRIES: "5"
       S3ND_UPLOAD_PARTSIZE: "50Mi"  # larger than test file size
       S3ND_UPLOAD_BWLIMIT: "160Mi"
+  sdfembs3-lsstcam-test:
+    image: "%{alias('s3daemon_default_image')}"
+    env:
+      <<: *sdfembs3
+      S3DAEMON_PORT: 15590
+  sdfembs3-lsstcam-test-s3nd:
+    image: "%{alias('s3nd_default_image')}"
+    env:
+      <<: *sdfembss3nd
+      S3ND_PORT: 15591

--- a/spec/fixtures/hieradata/site/cp/cluster/lsstcam-ccs.yaml
+++ b/spec/fixtures/hieradata/site/cp/cluster/lsstcam-ccs.yaml
@@ -12,3 +12,9 @@ s3daemon::instances:
   sdfembs3-lsstcam-s3nd:
     aws_access_key_id: "%{alias('s3daemon_test::aws_access_key_id')}"
     aws_secret_access_key: "%{alias('s3daemon_test::aws_secret_access_key')}"
+  sdfembs3-lsstcam-test:
+    aws_access_key_id: "%{alias('s3daemon_test::aws_access_key_id')}"
+    aws_secret_access_key: "%{alias('s3daemon_test::aws_secret_access_key')}"
+  sdfembs3-lsstcam-test-s3nd:
+    aws_access_key_id: "%{alias('s3daemon_test::aws_access_key_id')}"
+    aws_secret_access_key: "%{alias('s3daemon_test::aws_secret_access_key')}"

--- a/spec/support/spec/lsstcam.rb
+++ b/spec/support/spec/lsstcam.rb
@@ -70,4 +70,40 @@ shared_examples 'lsstcam-dc.cp' do
       }
     )
   end
+
+  it do
+    is_expected.to contain_s3daemon__instance('sdfembs3-lsstcam-test').with(
+      image: 'ghcr.io/lsst-dm/s3daemon:sha-57e1aa9',
+      volumes: [
+        '/data:/data',
+        '/home:/home',
+      ],
+      env: {
+        'S3_ENDPOINT_URL' => 'https://sdfembs3.sdf.slac.stanford.edu',
+        'S3DAEMON_PORT' => 15_590,
+        'S3DAEMON_HOST' => '0.0.0.0',
+      }
+    )
+  end
+
+  it do
+    is_expected.to contain_s3daemon__instance('sdfembs3-lsstcam-test-s3nd').with(
+      image: 'ghcr.io/lsst-dm/s3nd:1.0.1',
+      volumes: [
+        '/data:/data',
+        '/home:/home',
+      ],
+      env: {
+        'S3ND_ENDPOINT_URL' => 'https://sdfembs3.sdf.slac.stanford.edu',
+        'S3ND_PORT' => 15_591,
+        'S3ND_HOST' => '',
+        'S3ND_UPLOAD_TIMEOUT' => '10s',
+        'S3ND_QUEUE_TIMEOUT' => '30s',
+        'S3ND_UPLOAD_MAX_PARALLEL' => '25',
+        'S3ND_UPLOAD_TRIES' => '5',
+        'S3ND_UPLOAD_PARTSIZE' => '50Mi',  # larger than test file size
+        'S3ND_UPLOAD_BWLIMIT' => '160Mi',
+      }
+    )
+  end
 end


### PR DESCRIPTION
A different set of credentials is needed to access the `rubin-summit-users` bucket used for testing.

Related to https://github.com/lsst-it/lsst-puppet-hiera-private/pull/161