### PR TITLE
(site/dev) Add Kueyen Fluent Bit forward target in Puppet config

### DIFF
--- a/spec/support/spec/rsyslog.rb
+++ b/spec/support/spec/rsyslog.rb
@@ -131,6 +131,21 @@ shared_examples 'rsyslog defaults' do |site:|
         }
       )
     end
+
+    it do
+      is_expected.to contain_rsyslog__component__action('fluentbit_kueyen').with(
+        type: 'omfwd',
+        facility: '*.*',
+        config: {
+          'target' => 'rsyslog.fluent.kueyen.dev.lsst.org',
+          'port' => '5140',
+          'protocol' => 'tcp',
+          'StreamDriver' => 'ossl',
+          'StreamDriverMode' => '1',
+          'StreamDriverAuthMode' => 'anon',
+        }
+      )
+    end
   when 'tu'
     it do
       is_expected.to contain_rsyslog__component__action('graylogtu').with(


### PR DESCRIPTION
- Added new  omfwd action to rsyslog::config::actions
- Matches existing configuration style for ayekan and ruka targets
- Ensures logs are forwarded to Fluent Bit in the Kueyen environment