### PR TITLE
(cluster/rancher) migrate rancher.ls RKE2

### DIFF
--- a/hieradata/site/ls/cluster/rancher.yaml
+++ b/hieradata/site/ls/cluster/rancher.yaml
@@ -1,26 +1,5 @@
 ---
-nm::connections:
-  enp1s0:  # fqdn
-    content:
-      connection:
-        id: "enp1s0"
-        uuid: "a79e6dc7-7679-3237-a351-49132a22e919"
-        type: "ethernet"
-        interface-name: "enp1s0"
-      ethernet: {}
-      ipv4:
-        method: "auto"
-      ipv6:
-        method: "disabled"
-  enp2s0:
-    content:
-      connection:
-        id: "enp2s0"
-        uuid: "f6785b81-b268-3d77-bd7a-5833f9851108"
-        type: "ethernet"
-        interface-name: "enp2s0"
-      ethernet: {}
-      ipv4:
-        method: "disabled"
-      ipv6:
-        method: "disabled"
+rke2::config:
+  server: "https://rancher-api.%{::site}.lsst.org:9345"
+  tls-san:
+    - "rancher-api.%{::site}.lsst.org"

--- a/hieradata/site/ls/cluster/rancher/role/rke.yaml
+++ b/hieradata/site/ls/cluster/rancher/role/rke.yaml
@@ -1,4 +1,0 @@
----
-classes:
-  - "profile::core::sysctl::rp_filter"
-profile::core::sysctl::rp_filter::enable: false

--- a/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/rancher01.ls.lsst.org_spec.rb
@@ -19,7 +19,7 @@ describe 'rancher01.ls.lsst.org', :sitepp do
       end
       let(:node_params) do
         {
-          role: 'rke',
+          role: 'rke2server',
           site: 'ls',
           cluster: 'rancher',
         }
@@ -27,38 +27,16 @@ describe 'rancher01.ls.lsst.org', :sitepp do
 
       it { is_expected.to compile.with_all_deps }
 
-      include_examples 'docker', docker_version: '24.0.9'
-
       it do
-        is_expected.to contain_class('profile::core::rke').with(
-          version: '1.7.7'
+        is_expected.to contain_class('rke2').with(
+          node_type: 'server',
+          release_series: '1.31',
+          version: '1.31.8~rke2r1'
         )
       end
 
       include_examples 'vm'
-      include_context 'with nm interface'
-      it do
-        is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
-      end
-
-      it { is_expected.to have_nm__connection_resource_count(2) }
-
-      context 'with enp1s0' do
-        let(:interface) { 'enp1s0' }
-
-        it_behaves_like 'nm enabled interface'
-        it_behaves_like 'nm ethernet interface'
-        it_behaves_like 'nm dhcp interface'
-      end
-
-      context 'with enp2s0' do
-        let(:interface) { 'enp2s0' }
-
-        it_behaves_like 'nm enabled interface'
-        it_behaves_like 'nm ethernet interface'
-        it { expect(nm_keyfile['ipv4']['method']).to eq('disabled') }
-        it { expect(nm_keyfile['ipv6']['method']).to eq('disabled') }
-      end
+      it { is_expected.to have_nm__connection_resource_count(0) }
     end # on os
   end # on_supported_os
 end # role


### PR DESCRIPTION
Migrate rancher.ls to RKE2 and clean up old config for RKE1.

_when `cp` gets migrated, we can move this config to a higher hierarchy role as its the same for each site._