### PR TITLE
(common) bump s3nd to v1.5.2

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -575,7 +575,7 @@ restic::enable_backup: true
 restic::host: "s3.us-east-1.amazonaws.com"
 
 s3daemon_default_image: "ghcr.io/lsst-dm/s3daemon:sha-57e1aa9"
-s3nd_default_image: "ghcr.io/lsst-dm/s3nd:1.5.1"
+s3nd_default_image: "ghcr.io/lsst-dm/s3nd:1.5.2"
 s3daemon::volumes:
   - "/data:/data"
   - "/home:/home"

--- a/spec/hosts/nodes/auxtel-dc01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.cp.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'auxtel-dc01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('cp-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -71,7 +71,7 @@ describe 'auxtel-dc01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/hosts/nodes/auxtel-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.ls.lsst.org_spec.rb
@@ -45,7 +45,7 @@ describe 'auxtel-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('ls-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -73,7 +73,7 @@ describe 'auxtel-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/hosts/nodes/auxtel-dc01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc01.tu.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'auxtel-dc01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('tu-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -71,7 +71,7 @@ describe 'auxtel-dc01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-latiss-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/hosts/nodes/comcam-dc01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-dc01.cp.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'comcam-dc01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('cp-comcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -71,7 +71,7 @@ describe 'comcam-dc01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('sdfembs3-comcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-dc01.tu.lsst.org_spec.rb
@@ -43,7 +43,7 @@ describe 'comcam-dc01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('tu-comcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -71,7 +71,7 @@ describe 'comcam-dc01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-comcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -46,7 +46,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('ls-lsstcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -76,7 +76,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-lsstcam-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',
@@ -97,7 +97,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3daemon__instance('s3dfrgw-lsstcam-test-s3nd').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+          image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
           volumes: [
             '/data:/data',
             '/home:/home',

--- a/spec/support/spec/lsstcam.rb
+++ b/spec/support/spec/lsstcam.rb
@@ -18,7 +18,7 @@ shared_examples 'lsstcam-dc.cp' do
 
   it do
     is_expected.to contain_s3daemon__instance('cp-lsstcam-s3nd').with(
-      image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+      image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
       volumes: [
         '/data:/data',
         '/home:/home',
@@ -53,7 +53,7 @@ shared_examples 'lsstcam-dc.cp' do
 
   it do
     is_expected.to contain_s3daemon__instance('sdfembs3-lsstcam-s3nd').with(
-      image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+      image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
       volumes: [
         '/data:/data',
         '/home:/home',
@@ -89,7 +89,7 @@ shared_examples 'lsstcam-dc.cp' do
 
   it do
     is_expected.to contain_s3daemon__instance('sdfembs3-lsstcam-test-s3nd').with(
-      image: 'ghcr.io/lsst-dm/s3nd:1.5.1',
+      image: 'ghcr.io/lsst-dm/s3nd:1.5.2',
       volumes: [
         '/data:/data',
         '/home:/home',


### PR DESCRIPTION
Fixes CORS errors when accessing the /swagger/ endpoint with a browser.