### PR TITLE
(observer01.cp.lsst.org) Update network interface name

### DIFF
--- a/hieradata/node/observer01.cp.lsst.org.yaml
+++ b/hieradata/node/observer01.cp.lsst.org.yaml
@@ -2,13 +2,13 @@
 powertop::ensure: "absent"
 
 nm::connections:
-  enp10s0:
+  enp7s0:
     content:
       connection:
-        id: "enp10s0"
+        id: "enp7s0"
         uuid: "d0b09602-d300-4485-b005-3851181ee549"
         type: "ethernet"
-        interface-name: "enp10s0"
+        interface-name: "enp7s0"
       ethernet: {}
       ipv4:
         method: "auto"

--- a/spec/hosts/nodes/observer01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/observer01.cp.lsst.org_spec.rb
@@ -33,8 +33,8 @@ describe 'observer01.cp.lsst.org', :sitepp do
 
       it { is_expected.to have_nm__connection_resource_count(1) }
 
-      context 'with enp10s0' do
-        let(:interface) { 'enp10s0' }
+      context 'with enp7s0' do
+        let(:interface) { 'enp7s0' }
 
         it_behaves_like 'nm enabled interface'
         it_behaves_like 'nm ethernet interface'


### PR DESCRIPTION
I had to reinstall Linux on a machine and it renamed the network interface; causing some glitches with Foreman.