### PR TITLE
(common) allow remote connections to all deliverator instances

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -580,6 +580,7 @@ s3nd::volumes:
   - "/home:/home"
 s3nd::env:
   AWS_REGION: "lfa"
+  S3ND_HOST: ""  # allow connections from other nodes for metrics collection & testing
 
 pi::config::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete
 pi::cmdline::reboot: false  # XXX this should be removed when pi role/profile refactoring is complete

--- a/hieradata/site/cp/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/cp/cluster/lsstcam-ccs.yaml
@@ -19,7 +19,6 @@ s3nd::instances:
     port: 15571
     env:
       S3ND_ENDPOINT_URL: "https://s3.cp.lsst.org"
-      S3ND_HOST: ""  # allow connections from other nodes for testing
       S3ND_QUEUE_TIMEOUT: "15s"
       S3ND_UPLOAD_MAX_PARALLEL: "27"
       S3ND_UPLOAD_PARTSIZE: "100Mi"
@@ -30,7 +29,6 @@ s3nd::instances:
     port: 15581
     env: &sdfembss3nd
       S3ND_ENDPOINT_URL: "https://sdfembs3.sdf.slac.stanford.edu"
-      S3ND_HOST: ""  # allow connections from other nodes for testing
       S3ND_QUEUE_TIMEOUT: "15s"
       S3ND_UPLOAD_BWLIMIT: "4Gi"
       S3ND_UPLOAD_MAX_PARALLEL: "27"

--- a/hieradata/site/ls/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/ls/cluster/lsstcam-ccs.yaml
@@ -19,13 +19,11 @@ s3nd::instances:
     port: 15571
     env:
       S3ND_ENDPOINT_URL: "https://s3.ls.lsst.org"
-      S3ND_HOST: ""  # allow connections from other nodes for testing
   s3dfrgw-lsstcam:
     image: "%{alias('s3nd_default_image_ls')}"
     port: 15581
     env: &s3dfrgw
       S3ND_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"
-      S3ND_HOST: ""  # allow connections from other nodes for testing
       S3ND_QUEUE_TIMEOUT: "15s"
       S3ND_UPLOAD_BWLIMIT: "4Gi"
       S3ND_UPLOAD_MAX_PARALLEL: "27"

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -39,7 +39,6 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
           ],
           env: {
             'S3ND_ENDPOINT_URL' => 'https://s3.ls.lsst.org',
-            'S3ND_HOST' => '',
           }
         )
       end
@@ -54,7 +53,6 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
           ],
           env: {
             'S3ND_ENDPOINT_URL' => 'https://s3dfrgw.slac.stanford.edu',
-            'S3ND_HOST' => '',
             'S3ND_QUEUE_TIMEOUT' => '15s',
             'S3ND_UPLOAD_BWLIMIT' => '4Gi',
             'S3ND_UPLOAD_MAX_PARALLEL' => '27',
@@ -75,7 +73,6 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
           ],
           env: {
             'S3ND_ENDPOINT_URL' => 'https://s3dfrgw.slac.stanford.edu',
-            'S3ND_HOST' => '',
             'S3ND_QUEUE_TIMEOUT' => '15s',
             'S3ND_UPLOAD_BWLIMIT' => '4Gi',
             'S3ND_UPLOAD_MAX_PARALLEL' => '27',

--- a/spec/support/spec/lsstcam.rb
+++ b/spec/support/spec/lsstcam.rb
@@ -11,7 +11,6 @@ shared_examples 'lsstcam-dc.cp' do
       ],
       env: {
         'S3ND_ENDPOINT_URL' => 'https://s3.cp.lsst.org',
-        'S3ND_HOST' => '',
         'S3ND_QUEUE_TIMEOUT' => '15s',
         'S3ND_UPLOAD_MAX_PARALLEL' => '27',
         'S3ND_UPLOAD_PARTSIZE' => '100Mi',
@@ -31,7 +30,6 @@ shared_examples 'lsstcam-dc.cp' do
       ],
       env: {
         'S3ND_ENDPOINT_URL' => 'https://sdfembs3.sdf.slac.stanford.edu',
-        'S3ND_HOST' => '',
         'S3ND_QUEUE_TIMEOUT' => '15s',
         'S3ND_UPLOAD_BWLIMIT' => '4Gi',
         'S3ND_UPLOAD_MAX_PARALLEL' => '27',
@@ -52,7 +50,6 @@ shared_examples 'lsstcam-dc.cp' do
       ],
       env: {
         'S3ND_ENDPOINT_URL' => 'https://sdfembs3.sdf.slac.stanford.edu',
-        'S3ND_HOST' => '',
         'S3ND_QUEUE_TIMEOUT' => '15s',
         'S3ND_UPLOAD_BWLIMIT' => '4Gi',
         'S3ND_UPLOAD_MAX_PARALLEL' => '27',


### PR DESCRIPTION
This is necessary in order to enable prometheus metrics scraping.