### PR TITLE
(cluster/ruka) shutdown initrd configured interfaces

### DIFF
--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -7,6 +7,10 @@ clustershell::groupmembers:
       - "ruka[07-08]"
 profile::core::k8snode::enable_dhcp: true
 tuned::active_profile: "latency-performance"
+nm::conf:
+  device:
+    keep-configuration: "no"
+    allowed-connections: "except:origin:nm-initrd-generator"
 nm::connections:
   br2101:
     content:

--- a/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka01.dev.lsst.org_spec.rb
@@ -66,6 +66,15 @@ describe 'ruka01.dev.lsst.org', :sitepp do
         )
       end
 
+      it do
+        expect(catalogue.resource('class', 'nm')[:conf]).to include(
+          'device' => {
+            'keep-configuration' => 'no',
+            'allowed-connections' => 'except:origin:nm-initrd-generator',
+          }
+        )
+      end
+
       it { is_expected.to contain_class('cni::plugins::dhcp::service') }
 
       include_context 'with nm interface'

--- a/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka04.dev.lsst.org_spec.rb
@@ -67,6 +67,15 @@ describe 'ruka04.dev.lsst.org', :sitepp do
         )
       end
 
+      it do
+        expect(catalogue.resource('class', 'nm')[:conf]).to include(
+          'device' => {
+            'keep-configuration' => 'no',
+            'allowed-connections' => 'except:origin:nm-initrd-generator',
+          }
+        )
+      end
+
       it { is_expected.to contain_class('cni::plugins::dhcp::service') }
 
       include_context 'with nm interface'

--- a/spec/hosts/nodes/ruka07.dev.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ruka07.dev.lsst.org_spec.rb
@@ -42,6 +42,15 @@ describe 'ruka07.dev.lsst.org', :sitepp do
       end
 
       it do
+        expect(catalogue.resource('class', 'nm')[:conf]).to include(
+          'device' => {
+            'keep-configuration' => 'no',
+            'allowed-connections' => 'except:origin:nm-initrd-generator',
+          }
+        )
+      end
+
+      it do
         is_expected.to contain_class('profile::core::sysctl::rp_filter').with_enable(false)
       end
 


### PR DESCRIPTION
On at least some ruka nodes, the initrd is assigning an interface to eno1 via dhcp and this is resulting in multiple default routes.