### PR TITLE
(role/allsky-cam) update allskycam role

### DIFF
--- a/hieradata/role/allsky-cam.yaml
+++ b/hieradata/role/allsky-cam.yaml
@@ -3,19 +3,11 @@ classes:
   - "profile::core::common"
   - "profile::core::nfsclient"
 packages:
+  - "awscli2"
   - "libgphoto2"
-
-files:
-  /dimm:
-    ensure: "directory"
-    mode: "1777"
 
 nfs::client_enabled: true
 nfs::client_mounts:
-  /dimm:
-    share: "dimm"
-    server: "nfs-dimm.cp.lsst.org"
-    atboot: true
   /project:
     share: "project"
     server: "nfs-project.cp.lsst.org"

--- a/spec/hosts/roles/allsky_cam_spec.rb
+++ b/spec/hosts/roles/allsky_cam_spec.rb
@@ -30,15 +30,8 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples('common', os_facts:, site:)
+          it { is_expected.to contain_package('awscli2') }
           it { is_expected.to contain_package('libgphoto2') }
-
-          it do
-            is_expected.to contain_nfs__client__mount('/dimm').with(
-              share: 'dimm',
-              server: 'nfs-dimm.cp.lsst.org',
-              atboot: true
-            )
-          end
 
           it do
             is_expected.to contain_nfs__client__mount('/project').with(


### PR DESCRIPTION
-  Dimm mount no longer needed.
-  awscli2 package included it was manually installed before.