### PR TITLE
(Puppetfile) Switch Foreman Proxy to official version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -116,7 +116,7 @@ mod 'syseleven/restic', '2.8.1'
 mod 'theforeman/dhcp', '9.3.0'
 mod 'theforeman/dns', '11.1.0'
 mod 'theforeman/foreman', git: 'https://github.com/lsst-it/puppet-foreman', ref: '23f86f4'  # 20.2.0 + dep updates
-mod 'theforeman/foreman_proxy', git: 'https://github.com/lsst-it/puppet-foreman_proxy', ref: '90af64a'  # https://github.com/theforeman/puppet-foreman_proxy/pull/772 https://github.com/theforeman/puppet-foreman_proxy/pull/816
+mod 'theforeman/foreman_proxy', '28.2.0'
 mod 'theforeman/puppet', '21.1.0'
 mod 'theforeman/puppetserver_foreman', '4.2.2'
 mod 'theforeman/tftp', '9.1.0'


### PR DESCRIPTION
The commented PRs that @jhoblitt opened have been merged into the official Foreman Proxy module, for that reason, I would like to get us back on the official module.