### PR TITLE
(site/ls) bump deliverator to 1.9.1

### DIFF
--- a/hieradata/site/ls.yaml
+++ b/hieradata/site/ls.yaml
@@ -76,4 +76,4 @@ ccs_sal::lfa:
 
 ccs_software::influx_url: "https://ccs-influxdb.ls.lsst.org:443"
 
-s3nd_default_image_ls: "ghcr.io/lsst-dm/s3nd:1.9.0"
+s3nd_default_image_ls: "ghcr.io/lsst-dm/deliverator:1.9.1"

--- a/spec/hosts/nodes/auxtel-fp01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-fp01.ls.lsst.org_spec.rb
@@ -34,7 +34,7 @@ describe 'auxtel-fp01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('ls-latiss').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.9.0',
+          image: 'ghcr.io/lsst-dm/deliverator:1.9.1',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -48,7 +48,7 @@ describe 'auxtel-fp01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-latiss').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.9.0',
+          image: 'ghcr.io/lsst-dm/deliverator:1.9.1',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('ls-lsstcam').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.9.0',
+          image: 'ghcr.io/lsst-dm/deliverator:1.9.1',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -45,7 +45,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-lsstcam').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.9.0',
+          image: 'ghcr.io/lsst-dm/deliverator:1.9.1',
           port: 15_581,
           volumes: [
             '/data:/data',
@@ -65,7 +65,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-lsstcam-test').with(
-          image: 'ghcr.io/lsst-dm/s3nd:1.9.0',
+          image: 'ghcr.io/lsst-dm/deliverator:1.9.1',
           port: 15_591,
           volumes: [
             '/data:/data',


### PR DESCRIPTION
1.9.1 fixes the setting of a pacing rate on the s3 sockets.