### PR TITLE
(profile/tomcat) add puppet nginx configuration

### DIFF
--- a/site/profile/manifests/ccs/tomcat.pp
+++ b/site/profile/manifests/ccs/tomcat.pp
@@ -202,8 +202,9 @@ class profile::ccs::tomcat (
     ensure  => present,
     members => {
       'localhost:8080' => {
-        server => 'localhost',
-        port   => 8080,
+        server    => 'localhost',
+        port      => 8080,
+        max_fails => 0,
       },
     },
   }


### PR DESCRIPTION
Adds `max_fails=0` to tomcat nginx configuration. 

Ticket of reference: https://rubinobs.atlassian.net/browse/IT-6437