### PR TITLE
(foreman/cp) Add merken network dhcp

### DIFF
--- a/hieradata/node/foreman.cp.lsst.org.yaml
+++ b/hieradata/node/foreman.cp.lsst.org.yaml
@@ -47,18 +47,18 @@ dhcp::pools:
       - "139.229.161.40 139.229.161.42"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   MERKEN-FQDN:
-    network: "139.229.161.64"
+    network: "139.229.161.96"
     mask: "255.255.255.240"
-    gateway: "139.229.161.78"
-    range:
-      - "139.229.161.65 139.229.161.75"
-    search_domains: "%{alias('dhcp::dnsdomain')}"
-  MERKEN-METALLB:
-    network: "139.229.161.80"
-    mask: "255.255.255.224"
     gateway: "139.229.161.110"
     range:
-      - "139.229.161.81 139.229.161.107"
+      - "139.229.161.97 139.229.161.107"
+    search_domains: "%{alias('dhcp::dnsdomain')}"
+  MERKEN-METALLB:
+    network: "139.229.161.64"
+    mask: "255.255.255.224"
+    gateway: "139.229.161.94"
+    range:
+      - "139.229.161.65 139.229.161.91"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   IT-BMC:
     network: "139.229.162.0"

--- a/spec/hosts/nodes/foreman.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/foreman.cp.lsst.org_spec.rb
@@ -365,19 +365,19 @@ describe 'foreman.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_dhcp__pool('MERKEN-FQDN').with(
-          network: '139.229.161.64',
+          network: '139.229.161.96',
           mask: '255.255.255.240',
-          range: ['139.229.161.65 139.229.161.75'],
-          gateway: '139.229.161.78'
+          range: ['139.229.161.97 139.229.161.107'],
+          gateway: '139.229.161.110'
         )
       end
 
       it do
         is_expected.to contain_dhcp__pool('MERKEN-METALLB').with(
-          network: '139.229.161.80',
+          network: '139.229.161.64',
           mask: '255.255.255.224',
-          range: ['139.229.161.81 139.229.161.107'],
-          gateway: '139.229.161.110'
+          range: ['139.229.161.65 139.229.161.91'],
+          gateway: '139.229.161.94'
         )
       end
     end # on os


### PR DESCRIPTION
This pull request updates DHCP pool configurations for the `MERKEN-FQDN` and `MERKEN-METALLB` entries in `foreman.cp.lsst.org.yaml`. The changes shift the assigned IP address ranges, networks, and gateways for these pools.

DHCP pool configuration updates:

* [`MERKEN-FQDN`](diffhunk://#diff-64278c91ecf674617c91951d8b6075035247914409c7ca6fbe65cbeddb65f0c4L50-R61): Changed the `network` to `139.229.161.96`, the `gateway` to `139.229.161.110`, and the IP `range` to `139.229.161.97 139.229.161.107`.
* [`MERKEN-METALLB`](diffhunk://#diff-64278c91ecf674617c91951d8b6075035247914409c7ca6fbe65cbeddb65f0c4L50-R61): Changed the `network` to `139.229.161.64`, the `gateway` to `139.229.161.94`, and the IP `range` to `139.229.161.65 139.229.161.91`.