### PR TITLE
(common) bump deliverator to 2.4.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -574,7 +574,7 @@ restic::bucket: "rubin-bm-backups/%{facts.networking.fqdn}"
 restic::enable_backup: true
 restic::host: "s3.us-east-1.amazonaws.com"
 
-s3nd_default_image: "ghcr.io/lsst-dm/deliverator:2.3.0"
+s3nd_default_image: "ghcr.io/lsst-dm/deliverator:2.4.0"
 
 s3nd::volumes:
   - "/data:/data"

--- a/spec/hosts/nodes/auxtel-fp01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-fp01.cp.lsst.org_spec.rb
@@ -33,7 +33,7 @@ describe 'auxtel-fp01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('cp-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -47,7 +47,7 @@ describe 'auxtel-fp01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('sdfembs3-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/auxtel-fp01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-fp01.ls.lsst.org_spec.rb
@@ -34,7 +34,7 @@ describe 'auxtel-fp01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('ls-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -48,7 +48,7 @@ describe 'auxtel-fp01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/auxtel-fp01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-fp01.tu.lsst.org_spec.rb
@@ -32,7 +32,7 @@ describe 'auxtel-fp01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('tu-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -46,7 +46,7 @@ describe 'auxtel-fp01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-latiss').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/comcam-fp01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-fp01.cp.lsst.org_spec.rb
@@ -29,7 +29,7 @@ describe 'comcam-fp01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('cp-comcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -43,7 +43,7 @@ describe 'comcam-fp01.cp.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('sdfembs3-comcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/comcam-fp01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/comcam-fp01.tu.lsst.org_spec.rb
@@ -29,7 +29,7 @@ describe 'comcam-fp01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('tu-comcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -43,7 +43,7 @@ describe 'comcam-fp01.tu.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-comcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -31,7 +31,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('ls-lsstcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_571,
           volumes: [
             '/data:/data',
@@ -45,7 +45,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-lsstcam').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_581,
           volumes: [
             '/data:/data',
@@ -65,7 +65,7 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
 
       it do
         is_expected.to contain_s3nd__instance('s3dfrgw-lsstcam-test').with(
-          image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+          image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
           port: 15_591,
           volumes: [
             '/data:/data',

--- a/spec/support/spec/lsstcam.rb
+++ b/spec/support/spec/lsstcam.rb
@@ -3,7 +3,7 @@
 shared_examples 'lsstcam-dc.cp' do
   it do
     is_expected.to contain_s3nd__instance('cp-lsstcam').with(
-      image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+      image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
       port: 15_571,
       volumes: [
         '/data:/data',
@@ -22,7 +22,7 @@ shared_examples 'lsstcam-dc.cp' do
 
   it do
     is_expected.to contain_s3nd__instance('sdfembs3-lsstcam').with(
-      image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+      image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
       port: 15_581,
       volumes: [
         '/data:/data',
@@ -42,7 +42,7 @@ shared_examples 'lsstcam-dc.cp' do
 
   it do
     is_expected.to contain_s3nd__instance('sdfembs3-lsstcam-test').with(
-      image: 'ghcr.io/lsst-dm/deliverator:2.3.0',
+      image: 'ghcr.io/lsst-dm/deliverator:2.4.0',
       port: 15_591,
       volumes: [
         '/data:/data',


### PR DESCRIPTION
See: https://github.com/lsst-dm/deliverator/releases/tag/v2.4.0