### PR TITLE
(Puppetfile) Switch to local fork for puppet-tftp

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -119,6 +119,6 @@ mod 'theforeman/foreman', git: 'https://github.com/lsst-it/puppet-foreman', ref:
 mod 'theforeman/foreman_proxy', git: 'https://github.com/lsst-it/puppet-foreman_proxy', ref: '90af64a'  # https://github.com/theforeman/puppet-foreman_proxy/pull/772 https://github.com/theforeman/puppet-foreman_proxy/pull/816
 mod 'theforeman/puppet', '21.1.0'
 mod 'theforeman/puppetserver_foreman', '4.2.2'
-mod 'theforeman/tftp', '9.1.0'
+mod 'theforeman/tftp', git: 'https://github.com/lsst-it/puppet-tftp', ref: 'a27be8a' # Official module does not support EL8
 mod 'treydock/clustershell', '4.0.0'
 mod 'treydock/perfsonar', git: 'https://github.com/lsst-it/puppet-module-perfsonar', ref: '6e9449e'  # 4.1.0 + https://github.com/treydock/puppet-module-perfsonar/pull/26


### PR DESCRIPTION
Switching to a local fork because the official version dropped EL8