### PR TITLE
(role/foreman) extend dhcp lease time to 1day

### DIFF
--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -10,7 +10,7 @@ classes:
 
 dhcp::bootp: true
 dhcp::ddns_update_style: "none"
-dhcp::default_lease_time: &lease_time 900
+dhcp::default_lease_time: &lease_time 86400
 dhcp::logfacility: "daemon"
 dhcp::max_lease_time: *lease_time
 dhcp::option_static_route: true


### PR DESCRIPTION
This is intended to be a temporary extension of the dhcp lease time in order to facilitate smooth migration of the per site dhcp service off of each site's foreman vm while foreman is updated.