### PR TITLE
(profile::ccs::autologin) misc improvements

### DIFF
--- a/hieradata/role/ccs-viswork.yaml
+++ b/hieradata/role/ccs-viswork.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - "profile::ccs::autologin"
+  - "profile::ccs::autologout"
   - "profile::ccs::common"
   - "profile::ccs::graphical"
   - "profile::core::common"

--- a/site/profile/manifests/ccs/autologin.pp
+++ b/site/profile/manifests/ccs/autologin.pp
@@ -8,22 +8,23 @@ class profile::ccs::autologin (Boolean $enable = true) {
   if $enable {
     ensure_packages(['gdm'])
 
-    exec { 'Enable autologin for graphical ccs user':
+    exec { 'Enable timedlogin for graphical ccs user':
       path    => ['/usr/bin'],
-      unless  => 'grep -q ^AutomaticLogin /etc/gdm/custom.conf',
+      unless  => 'grep -q ^TimedLogin /etc/gdm/custom.conf',
       # lint:ignore:strict_indent
       command => @("CMD"/L),
         sed -i '/^\[daemon.*/a\\
-        AutomaticLogin=ccs\n\
-        AutomaticLoginEnable=true' /etc/gdm/custom.conf
+        TimedLogin=ccs\n\
+        TimedLoginDelay=60\n\
+        TimedLoginEnable=true' /etc/gdm/custom.conf
         | CMD
       # lint:endignore
     }
   } else {
-    exec { 'Disable autologin for graphical ccs user':
+    exec { 'Disable timedlogin for graphical ccs user':
       path    => ['/usr/bin'],
-      onlyif  => 'grep -q ^AutomaticLogin=ccs /etc/gdm/custom.conf',
-      command => 'sed -i "/^AutomaticLogin/d" /etc/gdm/custom.conf',
+      onlyif  => 'grep -q ^TimedLogin=ccs /etc/gdm/custom.conf',
+      command => 'sed -i "/^TimedLogin/d" /etc/gdm/custom.conf',
     }
   }
 }

--- a/site/profile/manifests/ccs/autologout.pp
+++ b/site/profile/manifests/ccs/autologout.pp
@@ -1,0 +1,27 @@
+# @summary
+#   Enable automatic logout for gnome sessions.
+#
+class profile::ccs::autologout {
+  $dconf_power = 'org/gnome/settings-daemon/plugins/power'
+  $dconf_sleep = 'sleep-inactive-ac'
+
+  ## Cannot lock -type, since need to change it for the ccs user.
+  dconf::settings { 'gnome power inactive-ac':
+    settings_hash => {
+      $dconf_power => {
+        "${dconf_sleep}-timeout" => { 'value' => 900, 'lock' => true },
+        "${dconf_sleep}-type"    => { 'value' => "'logout'", 'lock' => false },
+      },
+    },
+  }
+
+  ## Set sleep-inactive-ac-type='nothing' for the CCS user.
+  $ccs_user = 'ccs'
+
+  exec { 'ccs dconf disable autologout':
+    path    => ['/usr/bin/'],
+    command => "dbus-launch dconf write /${dconf_sleep}-type \"'nothing'\"",
+    user    => $ccs_user,
+    unless  => "dconf read /${dconf_sleep}-type | grep -q nothing",
+  }
+}


### PR DESCRIPTION
Use Timed rather than Automatic login, since the latter only works at boot, but the former works whenever someone logs out.
Auto-logout idle Gnome sessions of users other than CCS.