### PR TITLE
(auxtel) add dco missing role. Add spec test for host

### DIFF
--- a/hieradata/role/auxtel-vent-gate.yaml
+++ b/hieradata/role/auxtel-vent-gate.yaml
@@ -7,3 +7,4 @@ classes:
   - "profile::pi::darkmode"
   - "profile::pi::ftdi"
   - "profile::pi::pigpio"
+  - "profile::ts::dco"

--- a/spec/hosts/nodes/auxtel-vent-gates01.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-vent-gates01.cp.lsst.org_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'auxtel-vent-gates01.cp.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:node_params) do
+        {
+          role: 'auxtel-vent-gate',
+          site: 'cp',
+        }
+      end
+
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            cpuinfo: {
+                              'processor' => {
+                                'Model' => 'Raspberry Pi 4 Model B Rev 1.2',
+                              },
+                            },
+                            os: {
+                              'architecture' => 'aarch64',
+                            })
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples('common', os_facts:, site: 'cp')
+      include_examples 'docker'
+      include_examples('gpio', os_facts:)
+      include_examples('i2c', os_facts:)
+      include_examples 'darkmode'
+      include_examples 'ftdi'
+      include_examples 'pigpio'
+      include_examples 'dco'
+    end
+  end
+end

--- a/spec/hosts/roles/auxtel_vent_gate_spec.rb
+++ b/spec/hosts/roles/auxtel_vent_gate_spec.rb
@@ -38,6 +38,7 @@ describe "#{role} role" do
           include_examples 'darkmode'
           include_examples 'ftdi'
           include_examples 'pigpio'
+          include_examples 'dco'
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
Summary
•  Fixes a LoadError when targeting a node-level spec by adding a proper FQDN-based spec for the AuxTel vent gate.
•  Aligns the node spec with existing node spec patterns (e.g., auxtel-archiver, daq-mgt), rather than using a require_relative stub.

Changes
•  Added spec/hosts/nodes/auxtel-vent-gates01.cp.lsst.org_spec.rb:
◦  Uses :sitepp to compile against manifests/site.pp.
◦  Sets node_params: role 'auxtel-vent-gate', site 'cp'.
◦  Overrides facts to model a Raspberry Pi 4 (aarch64) and filters to AlmaLinux 9.
◦  Mirrors role coverage by including: common, docker, gpio, i2c, darkmode, ftdi, pigpio, dco examples.

Rationale
•  Brings the vent gate tests in line with other node specs and ensures the role is validated in the full Hiera/manifest context.

Test Plan
•  Run only this spec:
◦  bundle exec rake spec SPEC=spec/hosts/nodes/auxtel-vent-gates01.cp.lsst.org_spec.rb
