### PR TITLE
(*) ensure_packages() -> stdlib::ensure_packages()

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -19,5 +19,5 @@ $packages = lookup(
 )
 
 if ($packages) {
-  ensure_packages($packages)
+  stdlib::ensure_packages($packages)
 }

--- a/site/profile/manifests/ccs/autologin.pp
+++ b/site/profile/manifests/ccs/autologin.pp
@@ -6,7 +6,7 @@
 #
 class profile::ccs::autologin (Boolean $enable = true) {
   if $enable {
-    ensure_packages(['gdm'])
+    stdlib::ensure_packages(['gdm'])
 
     exec { 'Enable timedlogin for graphical ccs user':
       path    => ['/usr/bin'],

--- a/site/profile/manifests/ccs/common.pp
+++ b/site/profile/manifests/ccs/common.pp
@@ -50,6 +50,6 @@ class profile::ccs::common (
   }
 
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 }

--- a/site/profile/manifests/ccs/graphical.pp
+++ b/site/profile/manifests/ccs/graphical.pp
@@ -13,7 +13,7 @@ class profile::ccs::graphical (
   if $install {
     include profile::core::x2go
 
-    ensure_packages(['gdm'])
+    stdlib::ensure_packages(['gdm'])
 
     service { 'gdm':
       enable => true,
@@ -62,7 +62,7 @@ class profile::ccs::graphical (
         notify  => Package[$unwanted_gnome_pkgs],
       }
       ## There doesn't seem to be a group for this in epel9.
-      ensure_packages([
+      stdlib::ensure_packages([
           'mate-desktop',
           'mate-applets',
           'mate-menu',
@@ -80,11 +80,11 @@ class profile::ccs::graphical (
       ensure => purged,
     }
 
-    ensure_packages(['icewm'])
+    stdlib::ensure_packages(['icewm'])
   }
 
   if $officeapps {
-    ensure_packages(['libreoffice-base'])
+    stdlib::ensure_packages(['libreoffice-base'])
 
     if fact('os.release.major') == '9' {
       include 'google_chrome'

--- a/site/profile/manifests/ccs/nvidia.pp
+++ b/site/profile/manifests/ccs/nvidia.pp
@@ -9,7 +9,7 @@ class profile::ccs::nvidia (String $ensure = 'present') {
   if $ensure =~ /(present|absent)/ {
     ## This takes care of the /etc/kernel/postinst.d/ part,
     ## so long as the nvidia driver is installed with the dkms option.
-    ensure_packages(['dkms', 'gcc', 'kernel-devel', 'kernel-headers'])
+    stdlib::ensure_packages(['dkms', 'gcc', 'kernel-devel', 'kernel-headers'])
 
     $file = 'disable-nouveau.conf'
 

--- a/site/profile/manifests/ccs/postfix.pp
+++ b/site/profile/manifests/ccs/postfix.pp
@@ -18,6 +18,6 @@ class profile::ccs::postfix (
     content => $auth.unwrap,
   }
 
-  ensure_packages($packages)
+  stdlib::ensure_packages($packages)
   Package[$packages] -> Class['postfix']
 }

--- a/site/profile/manifests/core/bash_completion.pp
+++ b/site/profile/manifests/core/bash_completion.pp
@@ -7,5 +7,5 @@
 class profile::core::bash_completion (
   Array[String[1]] $packages,
 ) {
-  ensure_packages($packages)
+  stdlib::ensure_packages($packages)
 }

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -114,7 +114,7 @@ class profile::core::common (
       }
       default: { # EL9+
         if $manage_network_manager {
-          ensure_packages(['NetworkManager-initscripts-updown'])
+          stdlib::ensure_packages(['NetworkManager-initscripts-updown'])
           include nm
         }
       }

--- a/site/profile/manifests/core/convenience.pp
+++ b/site/profile/manifests/core/convenience.pp
@@ -8,6 +8,6 @@ class profile::core::convenience (
   Array[String] $packages,
 ) {
   unless (empty($packages)) {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 }

--- a/site/profile/manifests/core/debugutils.pp
+++ b/site/profile/manifests/core/debugutils.pp
@@ -8,6 +8,6 @@ class profile::core::debugutils (
   Array[String] $packages,
 ) {
   unless (empty($packages)) {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 }

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -104,5 +104,5 @@ class profile::core::docker (
     notify  => Service['docker'],
   }
 
-  ensure_packages(['docker-compose-plugin'])
+  stdlib::ensure_packages(['docker-compose-plugin'])
 }

--- a/site/profile/manifests/core/dtn.pp
+++ b/site/profile/manifests/core/dtn.pp
@@ -16,7 +16,7 @@ class profile::core::dtn (
   }
 
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   # Stop irqbalance

--- a/site/profile/manifests/core/foreman.pp
+++ b/site/profile/manifests/core/foreman.pp
@@ -160,7 +160,7 @@ class profile::core::foreman (
   }
 
   # for bmc management
-  ensure_packages(['ipmitool'])
+  stdlib::ensure_packages(['ipmitool'])
 
   package { 'oauth':
     ensure   => installed,

--- a/site/profile/manifests/core/foreman/fog_hack.pp
+++ b/site/profile/manifests/core/foreman/fog_hack.pp
@@ -7,7 +7,7 @@
 #   release of fog-libvirt is made.
 #
 class profile::core::foreman::fog_hack {
-  ensure_packages(['libvirt-devel'])
+  stdlib::ensure_packages(['libvirt-devel'])
 
   archive { 'fog-libvirt-0.11.0.gem':
     ensure => present,

--- a/site/profile/manifests/core/gpio.pp
+++ b/site/profile/manifests/core/gpio.pp
@@ -8,7 +8,7 @@ class profile::core::gpio (
   Optional[Array[String[1]]] $packages = undef,
 ) {
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   systemd::udev::rule { 'gpio.rules':

--- a/site/profile/manifests/core/i2c.pp
+++ b/site/profile/manifests/core/i2c.pp
@@ -8,12 +8,12 @@ class profile::core::i2c (
   Optional[Array[String[1]]] $packages = undef,
 ) {
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   # packages which do not exists in el7; mv to hiera when el7 is no longer supported
   if fact('os.family') == 'RedHat' and fact('os.release.major') == '9' {
-    ensure_packages(['python3-i2c-tools'])
+    stdlib::ensure_packages(['python3-i2c-tools'])
   }
 
   systemd::udev::rule { 'i2c.rules':

--- a/site/profile/manifests/core/ipam.pp
+++ b/site/profile/manifests/core/ipam.pp
@@ -149,8 +149,8 @@ class profile::core::ipam (
   }
 
   #  Packages installation
-  ensure_packages($mariadb_packages)
-  ensure_packages($packages)
+  stdlib::ensure_packages($mariadb_packages)
+  stdlib::ensure_packages($packages)
 
   #  HTTPD File definition
   file { '/etc/httpd/conf.d/ipam.conf':

--- a/site/profile/manifests/core/k8snode.pp
+++ b/site/profile/manifests/core/k8snode.pp
@@ -10,7 +10,7 @@ class profile::core::k8snode (
   $pkgs = [
     'gdisk',  # used to cleanup after rook-ceph
   ]
-  ensure_packages($pkgs)
+  stdlib::ensure_packages($pkgs)
 
   if $enable_dhcp {
     if $enable_dhcp == 'service_only' {

--- a/site/profile/manifests/core/letsencrypt.pp
+++ b/site/profile/manifests/core/letsencrypt.pp
@@ -46,11 +46,11 @@ class profile::core::letsencrypt (
       Package['python-s3transfer'],
     ],
   }
-  ensure_packages(['python-s3transfer'])
+  stdlib::ensure_packages(['python-s3transfer'])
 
   # XXX https://github.com/voxpupuli/puppet-letsencrypt/issues/230
   if fact('os.name') == 'CentOS' {
-    ensure_packages(['python2-futures.noarch'])
+    stdlib::ensure_packages(['python2-futures.noarch'])
   }
 
   if ($certonly) {

--- a/site/profile/manifests/core/ni_packages.pp
+++ b/site/profile/manifests/core/ni_packages.pp
@@ -27,5 +27,5 @@ class profile::core::ni_packages {
     ensure          => present,
     install_options => ['--enablerepo','nexus-ctio'];
   }
-  ensure_packages($packages)
+  stdlib::ensure_packages($packages)
 }

--- a/site/profile/manifests/core/perccli.pp
+++ b/site/profile/manifests/core/perccli.pp
@@ -4,5 +4,5 @@
 class profile::core::perccli {
   require profile::core::yum::dell
 
-  ensure_packages(['perccli'])
+  stdlib::ensure_packages(['perccli'])
 }

--- a/site/profile/manifests/core/x2go.pp
+++ b/site/profile/manifests/core/x2go.pp
@@ -8,7 +8,7 @@ class profile::core::x2go (
   Optional[Array[String[1]]] $packages = undef,
 ) {
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   # the rpm set mode for this file is 644, which upsets the visudo command

--- a/site/profile/manifests/pi/gpsd.pp
+++ b/site/profile/manifests/pi/gpsd.pp
@@ -16,7 +16,7 @@ class profile::pi::gpsd (
   Optional[String[1]] $options = undef,
 ) {
   if $packages {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   if $options {


### PR DESCRIPTION
Resolves this warning:

    Puppet This function is deprecated, please use stdlib::ensure_packages instead.