### PR TITLE
(node/auxtel-dc1.cp.lsst.org) add vm host

### DIFF
--- a/hieradata/node/auxtel-dc1.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-dc1.cp.lsst.org.yaml
@@ -1,0 +1,27 @@
+---
+nm::connections:
+  ens192:  # fqdn
+    content:
+      connection:
+        id: "ens192"
+        uuid: "f9e08f7e-0e02-387e-bc27-f49e5ea4e8c7"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}
+
+nfs::client_enabled: true
+
+nfs::client_mounts:
+  /data:
+    share: "data"
+    server: "auxtel-fp01.cp.lsst.org"
+    atboot: true
+  /repo:
+    share: "auxtel/repo"
+    server: "nfs-auxtel.cp.lsst.org"
+    atboot: true

--- a/spec/hosts/nodes/auxtel-dc1.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/auxtel-dc1.cp.lsst.org_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'auxtel-dc1.cp.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: false,
+                            virtual: 'physical',
+                            dmi: {
+                              'product' => {
+                                'name' => 'PowerEdge R630',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'ccs-dc',
+          cluster: 'auxtel-ccs',
+          site: 'cp',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm dhcp interface'
+        it_behaves_like 'nm ethernet interface'
+      end
+
+      it do
+        is_expected.to contain_nfs__client__mount('/data').with(
+          share: 'data',
+          server: 'auxtel-fp01.cp.lsst.org',
+          atboot: true
+        )
+      end
+
+      it do
+        is_expected.to contain_nfs__client__mount('/repo').with(
+          share: 'auxtel/repo',
+          server: 'nfs-auxtel.cp.lsst.org',
+          atboot: true
+        )
+      end
+    end
+  end # on os
+end # on_supported_os


### PR DESCRIPTION
Puppetizes auxtel-dc1.cp.lsst.org VM network configuration. This VM will be tested by Tony. If it behaves well, it will replace the auxtel-dc01.cp.lsst.org Dell server. 

Device was added on IPAM. 