### PR TITLE
(site/ls/cluster/lsstcam-ccs) set bwlimit for s3nd cp-lsstcam

### DIFF
--- a/hieradata/site/ls/cluster/lsstcam-ccs.yaml
+++ b/hieradata/site/ls/cluster/lsstcam-ccs.yaml
@@ -19,6 +19,12 @@ s3nd::instances:
     port: 15571
     env:
       S3ND_ENDPOINT_URL: "https://s3.ls.lsst.org"
+      S3ND_QUEUE_TIMEOUT: "20s"
+      S3ND_UPLOAD_BWLIMIT: "1Gi"
+      S3ND_UPLOAD_MAX_PARALLEL: "27"
+      S3ND_UPLOAD_PARTSIZE: "100Mi"
+      S3ND_UPLOAD_TIMEOUT: "15s"
+      S3ND_UPLOAD_TRIES: "2"
   s3dfrgw-lsstcam:
     image: "%{alias('s3nd_default_image_ls')}"
     port: 15581

--- a/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/lsstcam-dc01.ls.lsst.org_spec.rb
@@ -39,6 +39,12 @@ describe 'lsstcam-dc01.ls.lsst.org', :sitepp do
           ],
           env: {
             'S3ND_ENDPOINT_URL' => 'https://s3.ls.lsst.org',
+            'S3ND_QUEUE_TIMEOUT' => '20s',
+            'S3ND_UPLOAD_BWLIMIT' => '1Gi',
+            'S3ND_UPLOAD_MAX_PARALLEL' => '27',
+            'S3ND_UPLOAD_PARTSIZE' => '100Mi',
+            'S3ND_UPLOAD_TIMEOUT' => '15s',
+            'S3ND_UPLOAD_TRIES' => '2',
           }
         )
       end


### PR DESCRIPTION
s3.ls.lsst.org, currently hosted on konkong, isn't sized to handle ~8x10G bandwidth worth of uploads and frequent transfer timeouts are being observed.