### PR TITLE
(node/ipa1.cp.lsst.org) enable restic backups of ipa

### DIFF
--- a/hieradata/node/ipa1.cp.lsst.org.yaml
+++ b/hieradata/node/ipa1.cp.lsst.org.yaml
@@ -2,3 +2,4 @@
 network::interfaces_hash:
   eth0:  # fqdn
     ipaddress: "139.229.160.6"
+profile::core::restic::enable: true  # only backup primary ipa node

--- a/hieradata/role/ipareplica.yaml
+++ b/hieradata/role/ipareplica.yaml
@@ -3,6 +3,7 @@ classes:
   - "clustershell"
   - "ipa"
   - "profile::core::common"
+  - "profile::core::restic"
   - "tailscale"
 
 profile::core::common::disable_ipv6: true
@@ -60,3 +61,14 @@ hosts::entries:
     ip: "100.91.143.57"
   ipa3.cp.lsst.org:
     ip: "100.94.76.56"
+
+restic::repositories:
+  ipa:
+    backup_path:
+      - "/var/lib/ipa/backup"
+    backup_pre_cmd: "mkdir /var/lib/ipa/backup;/sbin/ipa-backup"
+    backup_post_cmd: "rm -rf /var/lib/ipa/backup"
+    backup_timer: "*-*-* 9:23:00"
+    enable_forget: true
+    forget_timer: "*-*-* 10:23:00"
+    forget_flags: "--keep-last 90"

--- a/site/profile/manifests/core/restic.pp
+++ b/site/profile/manifests/core/restic.pp
@@ -1,0 +1,13 @@
+# @summary
+#   Provides an easy way to turn restic backups on or off for a host.
+#
+# @param enable
+#   Whether to enable restic backups on this host.
+#
+class profile::core::restic (
+  Boolean $enable = false,
+) {
+  if $enable {
+    include restic
+  }
+}

--- a/spec/classes/core/restic_spec.rb
+++ b/spec/classes/core/restic_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::restic' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with no params' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_class('restic') }
+      end
+
+      context 'with enable param' do
+        let(:params) do
+          {
+            enable: true
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('restic') }
+      end
+    end
+  end
+end

--- a/spec/hosts/nodes/ipa1.cp.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ipa1.cp.lsst.org_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ipa1.cp.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'kvm',
+                            dmi: {
+                              'product' => {
+                                'name' => 'KVM',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'ipareplica',
+          site: 'cp',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_examples 'vm'
+      include_examples 'restic common'
+
+      it do
+        is_expected.to contain_restic__repository('ipa').with(
+          backup_path: %w[
+            /var/lib/ipa/backup
+          ],
+          backup_pre_cmd: 'mkdir /var/lib/ipa/backup;/sbin/ipa-backup',
+          backup_post_cmd: 'rm -rf /var/lib/ipa/backup',
+          backup_timer: '*-*-* 9:23:00',
+          enable_forget: true,
+          forget_timer: '*-*-* 10:23:00',
+          forget_flags: '--keep-last 90'
+        )
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
As this is an offline backup, which takes down freeipa, we only want to enable it on a single node at a time.