### PR TITLE
(Puppetfile) roll back sshkeys

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -73,7 +73,7 @@ mod 'puppetlabs/puppetdb', '8.1.0'
 mod 'puppetlabs/puppetserver_gem', '1.1.1'
 mod 'puppetlabs/reboot', '5.1.0'
 mod 'puppetlabs/selinux_core', '2.0.1'
-mod 'puppetlabs/sshkeys_core', '3.0.1'
+mod 'puppetlabs/sshkeys_core', '2.5.1'
 mod 'puppetlabs/stdlib', '9.7.0'
 mod 'puppetlabs/tomcat', git: 'https://github.com/lsst-it/puppetlabs-tomcat', ref: '11c0817' # Using this fork while we wait for dependencies to be merged here: https://github.com/puppetlabs/puppetlabs-tomcat/pull/581
 mod 'puppetlabs/transition', '2.0.0'


### PR DESCRIPTION
Fix as the new version of sshkeys only supports Puppet 8