### PR TITLE
(node/tma-bosh) add network & test

### DIFF
--- a/hieradata/node/tma-almalinux-bosh.ls.lsst.org.yaml
+++ b/hieradata/node/tma-almalinux-bosh.ls.lsst.org.yaml
@@ -1,0 +1,18 @@
+---
+nm::connections:
+  ens192:
+    content:
+      connection:
+        id: "ens192"
+        uuid: "03da7500-2101-c722-2438-d0d006c28c73"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        address1: "139.229.138.2/24,139.229.138.254"
+        dns: "139.229.135.53;139.229.135.54;139.229.135.55;"
+        dns-search: "ls.lsst.org;"
+        method: "manual"
+      ipv6:
+        method: "ignore"
+      proxy: {}

--- a/spec/hosts/nodes/tma-almalinux-bosh.ls.lsst.org.rb
+++ b/spec/hosts/nodes/tma-almalinux-bosh.ls.lsst.org.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'vpn1.ls.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'vmware',
+                            dmi: {
+                              'product' => {
+                                'name' => 'VMware7,1',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'ls',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it { expect(nm_keyfile['ipv4']['address1']).to eq('139.229.145.120/24,139.229.145.254') }
+        it { expect(nm_keyfile['ipv4']['dns']).to eq('139.229.135.53;139.229.135.54;139.229.135.55;') }
+        it { expect(nm_keyfile['ipv4']['dns-search']).to eq('ls.lsst.org;') }
+        it { expect(nm_keyfile['ipv4']['method']).to eq('manual') }
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
This PR adds network configuration and tests to tma-almalinux-bosh.ls.lsst.org