### PR TITLE
(role/openvpnas) add logs configuration

### DIFF
--- a/hieradata/role/openvpnas.yaml
+++ b/hieradata/role/openvpnas.yaml
@@ -22,3 +22,9 @@ profile::core::openvpnas::vpn_groups:
     superuser: false
   vpn-clyso:
     superuser: false
+
+rsyslog::config::custom_config:
+  openvpnas_forward:
+    target: 'openvpnas.conf'
+    content: |
+      if $programname == 'openvpnas' then @collector.ls.lsst.org:5143


### PR DESCRIPTION
This puppetizes rsyslog vpn file to send logs.

Example taken:


```shell
[root@vpn01 rsyslog.d] cat /etc/rsyslog.d/openvpnas.conf
# This file is managed by Puppet. DO NOT EDIT.
if $programname == 'openvpnas' then @collector.ls.lsst.org:5143
``` 