### PR TITLE
(role/niagara) add hvac restic backup

### DIFF
--- a/hieradata/role/niagara.yaml
+++ b/hieradata/role/niagara.yaml
@@ -5,3 +5,14 @@ classes:
 sudo::configs:
   niagara_sudoers:
     content: "%niagara ALL=(ALL) NOPASSWD: /usr/bin/niagaradctl"
+
+profile::core::restic::enable: true
+restic::repositories:
+  awsrepo:
+    backup_path:
+      - "/etc/mosquitto"
+      - "/opt/Niagara"
+    backup_timer: "*-*-* 09:00:00"
+    enable_forget: true
+    forget_timer: "Mon..Sun 23:00:00"
+    forget_flags: "--keep-last 20"

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -71,6 +71,7 @@ class profile::core::common (
   include profile::core::keytab
   include profile::core::nm_dispatch
   include profile::core::node_info
+  include profile::core::restic
   include profile::core::selinux
   include profile::core::systemd
   include rsyslog

--- a/spec/hosts/roles/niagara_spec.rb
+++ b/spec/hosts/roles/niagara_spec.rb
@@ -22,6 +22,20 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples('common', os_facts:, site:)
+
+          it { is_expected.to contain_sudo__conf('niagara_sudoers').with_content('%niagara ALL=(ALL) NOPASSWD: /usr/bin/niagaradctl') }
+
+          it { is_expected.to contain_class('restic') }
+
+          it {
+            is_expected.to contain_restic__repository('awsrepo').with(
+              backup_path: ['/etc/mosquitto', '/opt/Niagara'],
+              backup_timer: '*-*-* 09:00:00',
+              enable_forget: true,
+              forget_timer: 'Mon..Sun 23:00:00',
+              forget_flags: '--keep-last 20'
+            )
+          }
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
1. Adds the ability to perform restic backups on some bare metal hosts. 
2. `profile::core:restic` was moved inside `profile::core::common` to discontinue the direct inclusion of `restic` on other roles.