### PR TITLE
(profile::core:openvpnas) add ldap filter

### DIFF
--- a/hieradata/node/vpn07.ls.lsst.org.yaml
+++ b/hieradata/node/vpn07.ls.lsst.org.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::openvpnas::ldap_add_req: 'memberOf=cn=vpn-backup,cn=groups,cn=accounts,dc=lsst,dc=cloud'

--- a/site/profile/manifests/core/openvpnas.pp
+++ b/site/profile/manifests/core/openvpnas.pp
@@ -11,10 +11,15 @@
 #   Hash of VPN groups to create with their properties.
 #   Example: { 'vpn-it' => { 'superuser' => true }, 'vpn-default' => { 'superuser' => false } }
 #
+# @param ldap_add_req
+#   LDAP additional requirement filter for OpenVPN AS (auth.ldap.0.add_req).
+#   Defaults to requiring membership in the 'vpn' group; can be overridden per-node in Hiera.
+#
 class profile::core::openvpnas (
   String[1] $version,
   Optional[String[1]] $bind_pw = undef,
   Hash[String, Hash] $vpn_groups = {},
+  String[1] $ldap_add_req = 'memberOf=cn=vpn,cn=groups,cn=accounts,dc=lsst,dc=cloud',
 ) {
   include profile::core::letsencrypt
   $fqdn    = $facts['networking']['fqdn']
@@ -65,7 +70,7 @@ class profile::core::openvpnas (
   }
   openvpnas::config::key { 'auth.ldap.0.add_req':
     key   => 'auth.ldap.0.add_req',
-    value => 'memberOf=cn=vpn,cn=groups,cn=accounts,dc=lsst,dc=cloud',
+    value => $ldap_add_req,
   }
   openvpnas::config::key { 'auth.ldap.0.uname_attr':
     key   => 'auth.ldap.0.uname_attr',

--- a/site/profile/manifests/core/openvpnas.pp
+++ b/site/profile/manifests/core/openvpnas.pp
@@ -63,6 +63,10 @@ class profile::core::openvpnas (
     key   => 'auth.ldap.0.users_base_dn',
     value => 'cn=accounts,dc=lsst,dc=cloud',
   }
+  openvpnas::config::key { 'auth.ldap.0.add_req':
+    key   => 'auth.ldap.0.add_req',
+    value => 'memberOf=cn=vpn,cn=groups,cn=accounts,dc=lsst,dc=cloud',
+  }
   openvpnas::config::key { 'auth.ldap.0.uname_attr':
     key   => 'auth.ldap.0.uname_attr',
     value => 'uid',

--- a/spec/classes/core/openvpnas_spec.rb
+++ b/spec/classes/core/openvpnas_spec.rb
@@ -60,6 +60,13 @@ describe 'profile::core::openvpnas' do
         end
 
         it do
+          is_expected.to contain_openvpnas__config__key('auth.ldap.0.add_req').with(
+            key: 'auth.ldap.0.add_req',
+            value: 'memberOf=cn=vpn,cn=groups,cn=accounts,dc=lsst,dc=cloud'
+          )
+        end
+
+        it do
           is_expected.to contain_openvpnas__config__key('auth.ldap.0.uname_attr').with(
             key: 'auth.ldap.0.uname_attr',
             value: 'uid'

--- a/spec/classes/core/openvpnas_spec.rb
+++ b/spec/classes/core/openvpnas_spec.rb
@@ -203,6 +203,24 @@ describe 'profile::core::openvpnas' do
           )
         end
       end
+
+      context 'with custom ldap_add_req' do
+        let(:params) do
+          {
+            version: '3.0.2_87c70987',
+            ldap_add_req: 'memberOf=cn=vpn-backup,cn=groups,cn=accounts,dc=lsst,dc=cloud'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_openvpnas__config__key('auth.ldap.0.add_req').with(
+            key: 'auth.ldap.0.add_req',
+            value: 'memberOf=cn=vpn-backup,cn=groups,cn=accounts,dc=lsst,dc=cloud'
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds missing  LDAP filter to install. 