### PR TITLE
(role/dnscache) add dnssec exception for lsst.local

### DIFF
--- a/hieradata/role/dnscache.yaml
+++ b/hieradata/role/dnscache.yaml
@@ -5,6 +5,9 @@ classes:
 dns::forward: "only"
 dns::listen_on_v6: false
 dns::sysconfig_startup_options: "-4"
+dns::dnssec_validation: "auto"
+dns::additional_options:
+  "validate-except": '{ "lsst.local"; }'
 dns::additional_directives:
   - "logging {"
   - "    channel queries_syslog {"

--- a/spec/hosts/roles/dnscache_spec.rb
+++ b/spec/hosts/roles/dnscache_spec.rb
@@ -29,7 +29,11 @@ describe "#{role} role" do
                 '1.0.0.1',
                 '1.1.1.1',
                 '8.8.8.8',
-              ]
+              ],
+              dnssec_validation: 'auto',
+              additional_options: {
+                'validate-except' => '{ "lsst.local"; }',
+              }
             )
           end
 


### PR DESCRIPTION
This fixes the problem of not being able to reach lsst.local on our networks. This adds lsst.local as an exception to our DNSSec policy of `auto` (turned on), by adding a DNS class and a test for it.