### PR TITLE
(toqui) replace name from toki to toqui

### DIFF
--- a/hieradata/cluster/machi.yaml
+++ b/hieradata/cluster/machi.yaml
@@ -3,9 +3,9 @@ clustershell::groupmembers:
   machi:
     group: "machi"
     member: "machi[01-48]"
-  toki:
-    group: "toki"
-    member: "toki[01-18]"
+  toqui:
+    group: "toqui"
+    member: "toqui[01-18]"
 tuned::active_profile: "latency-performance"
 nm::conf:
   device:

--- a/hieradata/node/foreman.ls.lsst.org.yaml
+++ b/hieradata/node/foreman.ls.lsst.org.yaml
@@ -250,7 +250,7 @@ dhcp::pools:
     range:
       - "139.229.143.83 139.229.143.123"
     search_domains: "%{alias('dhcp::dnsdomain')}"
-  TOKI:  # vlan2142
+  TOQUI:  # vlan2142
     network: "139.229.143.128"
     mask: "255.255.255.224"
     gateway: "139.229.143.158"

--- a/spec/hosts/nodes/foreman.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/foreman.ls.lsst.org_spec.rb
@@ -342,7 +342,7 @@ describe 'foreman.ls.lsst.org', :sitepp do
       end
 
       it do
-        is_expected.to contain_dhcp__pool('TOKI').with(
+        is_expected.to contain_dhcp__pool('TOQUI').with(
           network: '139.229.143.128',
           mask: '255.255.255.224',
           gateway: '139.229.143.158',

--- a/spec/hosts/nodes/machi01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/machi01.ls.lsst.org_spec.rb
@@ -50,9 +50,9 @@ describe 'machi01.ls.lsst.org', :sitepp do
               'group' => 'machi',
               'member' => 'machi[01-48]',
             },
-            'toki' => {
-              'group' => 'toki',
-              'member' => 'toki[01-18]',
+            'toqui' => {
+              'group' => 'toqui',
+              'member' => 'toqui[01-18]',
             },
           },
         )

--- a/spec/hosts/nodes/machi06.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/machi06.ls.lsst.org_spec.rb
@@ -50,9 +50,9 @@ describe 'machi06.ls.lsst.org', :sitepp do
               'group' => 'machi',
               'member' => 'machi[01-48]',
             },
-            'toki' => {
-              'group' => 'toki',
-              'member' => 'toki[01-18]',
+            'toqui' => {
+              'group' => 'toqui',
+              'member' => 'toqui[01-18]',
             },
           },
         )


### PR DESCRIPTION
- Updates the cluster name to its correct format.
- IPAM was updated to reflect this along with foreman LS settings.  