### PR TITLE
(role/puppetdb) bump java args resources

### DIFF
--- a/hieradata/role/puppetdb.yaml
+++ b/hieradata/role/puppetdb.yaml
@@ -22,8 +22,8 @@ puppetdb::manage_package_repo: false
 puppetdb::postgres_version: "15"
 puppetdb::ssl_listen_address: "0.0.0.0"
 puppetdb::java_args:
-  "-Xmx": "1g"
-  "-Xms": "512m"
+  "-Xmx": "3g"
+  "-Xms": "1536m"
 
 profile::core::firewall::firewall:
   "250 accept http - redirect to 443":

--- a/spec/hosts/roles/puppetdb_spec.rb
+++ b/spec/hosts/roles/puppetdb_spec.rb
@@ -33,8 +33,8 @@ shared_examples 'puppetdb' do
     is_expected.to contain_class('puppetdb').with(
       listen_address: 'localhost',
       java_args: {
-        '-Xmx' => '1g',
-        '-Xms' => '512m',
+        '-Xmx' => '3g',
+        '-Xms' => '1536m',
       },
     )
   end


### PR DESCRIPTION
Bumps JVM heap limit from 1GB to 3GB as it's too small for the workload it handles.

This was causing OOM and puppet db to crash thus generating big amounts of logs. 