### PR TITLE
(hierdata/cluster) update cluster shell group

### DIFF
--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -2,7 +2,7 @@
 clustershell::groupmembers:
   manke:
     group: "manke"
-    member: "manke[01-10]"
+    member: "manke[01-11]"
 profile::core::k8snode::enable_dhcp: true
 tuned::active_profile: "latency-performance"
 nm::conf:

--- a/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/manke01.ls.lsst.org_spec.rb
@@ -48,7 +48,7 @@ describe 'manke01.ls.lsst.org', :sitepp do
           groupmembers: {
             'manke' => {
               'group' => 'manke',
-              'member' => 'manke[01-10]',
+              'member' => 'manke[01-11]',
             },
           },
         )


### PR DESCRIPTION
This PR updates the cluster shell group members from 10 to 11 which is the amount of Manke nodes that we have. 