### PR TITLE
(role/daq-mgt) add rce SSH config for DAQ network

### DIFF
--- a/hieradata/role/daq-mgt.yaml
+++ b/hieradata/role/daq-mgt.yaml
@@ -55,3 +55,28 @@ accounts::user_list:
     <<: *daq_user
     uid: 62003
     gid: 62003
+
+# SSH key and config for rce service account to connect to RCE embedded
+# systems on the DAQ network (192.168.100.0/24).
+# The .ssh directory is created by the accounts module (managehome: true).
+# The private key content is in lsst-puppet-hiera-private/role/daq-mgt.eyaml.
+files:
+  "/home/rce/.ssh/config":
+    ensure: "file"
+    mode: "0644"
+    owner: &rce_uid 62002
+    group: *rce_uid
+    backup: false
+    show_diff: false
+    content: |
+      # Managed by Puppet - do not edit
+      Host 192.168.100.*
+          User root
+          Port 22
+          IdentityFile ~/.ssh/rce_rsa
+          StrictHostKeyChecking no
+          UserKnownHostsFile /dev/null
+          LogLevel ERROR
+          ForwardX11 no
+          ForwardAgent no
+          BatchMode yes

--- a/spec/hosts/roles/daq_mgt_spec.rb
+++ b/spec/hosts/roles/daq_mgt_spec.rb
@@ -41,6 +41,23 @@ shared_examples 'generic daq manager' do |os_facts:, site:|
       shell: '/sbin/nologin',
     )
   end
+
+  # rce SSH config for connecting to RCE embedded systems
+  # Note: /home/rce/.ssh directory is created by the accounts module (managehome: true)
+  it do
+    is_expected.to contain_file('/home/rce/.ssh/config').with(
+      ensure: 'file',
+      mode: '0644',
+      owner: 62_002,
+      group: 62_002,
+    ).with_content(%r{Host 192\.168\.100\.\*})
+      .with_content(%r{IdentityFile ~/.ssh/rce_rsa})
+      .with_content(%r{User root})
+      .with_content(%r{StrictHostKeyChecking no})
+      .with_content(%r{ForwardX11 no})
+      .with_content(%r{ForwardAgent no})
+      .with_content(%r{BatchMode yes})
+  end
 end
 
 role = 'daq-mgt'

--- a/spec/hosts/roles/daq_mgt_spec.rb
+++ b/spec/hosts/roles/daq_mgt_spec.rb
@@ -51,12 +51,12 @@ shared_examples 'generic daq manager' do |os_facts:, site:|
       owner: 62_002,
       group: 62_002,
     ).with_content(%r{Host 192\.168\.100\.\*})
-      .with_content(%r{IdentityFile ~/.ssh/rce_rsa})
-      .with_content(%r{User root})
-      .with_content(%r{StrictHostKeyChecking no})
-      .with_content(%r{ForwardX11 no})
-      .with_content(%r{ForwardAgent no})
-      .with_content(%r{BatchMode yes})
+                                                        .with_content(%r{IdentityFile ~/.ssh/rce_rsa})
+                                                        .with_content(%r{User root})
+                                                        .with_content(%r{StrictHostKeyChecking no})
+                                                        .with_content(%r{ForwardX11 no})
+                                                        .with_content(%r{ForwardAgent no})
+                                                        .with_content(%r{BatchMode yes})
   end
 end
 


### PR DESCRIPTION
As described in https://rubinobs.atlassian.net/browse/IT-6906, this adds the RCE ssh key to the rce users .ssh file and sets the ssh config to use it when communicating with the RCEs on the private DAQ network.