### PR TITLE
(profile::ccs::file_transfer) remove -s3nd script versions

### DIFF
--- a/site/profile/manifests/ccs/file_transfer.pp
+++ b/site/profile/manifests/ccs/file_transfer.pp
@@ -96,13 +96,9 @@ class profile::ccs::file_transfer (
     'fpack-in-place',
     'generate-sidecar',
     'push-additional-oods',
-    'push-additional-oods-s3nd',
     'push-additional-usdf',
-    'push-additional-usdf-s3nd',
     'push-oods',
-    'push-oods-s3nd',
     'push-usdf',
-    'push-usdf-s3nd',
     'send-s3nd',
   ]
   $script_files.each | String $scriptfile | {


### PR DESCRIPTION
These are no longer used.