### PR TITLE
(node/ats-*) add missing network configs and tests

### DIFF
--- a/hieradata/node/ats-bosch.ls.lsst.org.yaml
+++ b/hieradata/node/ats-bosch.ls.lsst.org.yaml
@@ -1,0 +1,15 @@
+---
+nm::connections:
+  ens192:
+    content:
+      connection:
+        id: "ens192"
+        uuid: "1a783b2b-0657-445a-981b-17434ebc0217"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}

--- a/hieradata/node/ats-manager.ls.lsst.org.yaml
+++ b/hieradata/node/ats-manager.ls.lsst.org.yaml
@@ -1,0 +1,15 @@
+---
+nm::connections:
+  ens192:
+    content:
+      connection:
+        id: "ens192"
+        uuid: "7b9749a4-55dd-47ee-b971-bd23c47dc171"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}

--- a/hieradata/node/ats-run-test.ls.lsst.org.yaml
+++ b/hieradata/node/ats-run-test.ls.lsst.org.yaml
@@ -1,0 +1,15 @@
+---
+nm::connections:
+  ens192:
+    content:
+      connection:
+        id: "ens192"
+        uuid: "eff428c2-4eb2-4ed5-8ecc-6650d599401e"
+        type: "ethernet"
+        interface-name: "ens192"
+      ethernet: {}
+      ipv4:
+        method: "auto"
+      ipv6:
+        method: "disabled"
+      proxy: {}

--- a/spec/hosts/nodes/ats-bosch.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ats-bosch.ls.lsst.org_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ats-bosch.ls.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'vmware',
+                            dmi: {
+                              'product' => {
+                                'name' => 'VMware7,1',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'ls',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it_behaves_like 'nm dhcp interface'
+      end
+    end # on os
+  end # on_supported_os
+end

--- a/spec/hosts/nodes/ats-manager.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ats-manager.ls.lsst.org_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ats-manager.ls.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'vmware',
+                            dmi: {
+                              'product' => {
+                                'name' => 'VMware7,1',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'ls',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it_behaves_like 'nm dhcp interface'
+      end
+    end # on os
+  end # on_supported_os
+end

--- a/spec/hosts/nodes/ats-run-test.ls.lsst.org_spec.rb
+++ b/spec/hosts/nodes/ats-run-test.ls.lsst.org_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ats-run-test.ls.lsst.org', :sitepp do
+  on_supported_os.each do |os, os_facts|
+    next unless os =~ %r{almalinux-9-x86_64}
+
+    context "on #{os}" do
+      let(:facts) do
+        lsst_override_facts(os_facts,
+                            is_virtual: true,
+                            virtual: 'vmware',
+                            dmi: {
+                              'product' => {
+                                'name' => 'VMware7,1',
+                              },
+                            })
+      end
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'ls',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      include_context 'with nm interface'
+      it { is_expected.to have_nm__connection_resource_count(1) }
+
+      context 'with ens192' do
+        let(:interface) { 'ens192' }
+
+        it_behaves_like 'nm enabled interface'
+        it_behaves_like 'nm ethernet interface'
+        it_behaves_like 'nm dhcp interface'
+      end
+    end # on os
+  end # on_supported_os
+end


### PR DESCRIPTION
Upon reboot the 3 hosts do not bring up their network interfaces on their own. These three network configurations should fix that bug allowing them to be connected to network on boot.