### PR TITLE
(common) add ccs_sal::rpms, to work around an error

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -508,6 +508,11 @@ nfs::nfs_v4_idmap_domain: "%{facts.networking.domain}"
 profile::ccs::common::pkgurl: "https://repo-nexus.lsst.org/nexus/repository/ccs_private"
 ccs_hcu::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
 ccs_monit::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
+## The following is no longer used by ccs_sal and should not be needed.
+## However without it, for unknown reasons the following error was thrown:
+##  Class[Ccs_sal]: expects a value for parameter 'rpms'
+ccs_sal::rpms:
+  ts_sal_utilsKafka: "ts_sal_utilsKafka-10.1.1-1.x86_64.rpm"
 
 systemd::manage_udevd: true
 


### PR DESCRIPTION
Without this we get the following error, no idea why:
  Error while evaluating a Method call, Class[Ccs_sal]: expects a value
  for parameter 'rpms'