### PR TITLE
(node/comcam-db01.cp) do not manage the database service state

### DIFF
--- a/hieradata/node/comcam-db01.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-db01.cp.lsst.org.yaml
@@ -17,3 +17,9 @@ network::interfaces_hash:
     bootproto: "none"
     onboot: "no"
     type: "Ethernet"
+## Moved to comcam-db02:
+ccs_database::service_manage: false
+#ccs_software::services:
+#  prod:
+#    - "rest-server"
+#    - "localdb"


### PR DESCRIPTION
Since comcam-db02 is now the main database server, we do not want the mariadb service to be automatically started on db01.